### PR TITLE
Respect reduced motion in loading screen

### DIFF
--- a/src/components/UI/LoadingScreen.jsx
+++ b/src/components/UI/LoadingScreen.jsx
@@ -1,91 +1,82 @@
-import { jsxDEV } from "react/jsx-dev-runtime";
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+const getPrefersReducedMotion = () => {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+};
+
 const LoadingScreen = ({ progress }) => {
-  return /* @__PURE__ */ jsxDEV("div", { className: "w-full h-full relative", children: [
-    /* @__PURE__ */ jsxDEV(
-      "div",
-      {
-        className: "absolute inset-0 bg-cover bg-center",
-        style: { backgroundImage: "url('/loading1.png')" }
-      },
-      void 0,
-      false,
-      {
-        fileName: "<stdin>",
-        lineNumber: 7,
-        columnNumber: 13
-      }
-    ),
-    /* @__PURE__ */ jsxDEV("div", { className: "absolute inset-0 bg-black bg-opacity-60" }, void 0, false, {
-      fileName: "<stdin>",
-      lineNumber: 12,
-      columnNumber: 13
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(getPrefersReducedMotion);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(REDUCED_MOTION_QUERY);
+
+    const handleChange = (event) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    if (typeof mediaQueryList.addEventListener === "function") {
+      mediaQueryList.addEventListener("change", handleChange);
+      return () => mediaQueryList.removeEventListener("change", handleChange);
+    }
+
+    mediaQueryList.addListener(handleChange);
+    return () => mediaQueryList.removeListener(handleChange);
+  }, []);
+
+  const progressBarClasses = useMemo(() => {
+    const classes = [
+      "bg-yellow-500 h-full rounded-full text-center text-black font-bold leading-8"
+    ];
+
+    if (!prefersReducedMotion) {
+      classes.push("transition-all duration-500 ease-out");
+    }
+
+    return classes.join(" ");
+  }, [prefersReducedMotion]);
+
+  const progressBarStyle = useMemo(
+    () => ({
+      width: `${progress}%`,
+      ...(prefersReducedMotion ? { transition: "none" } : {})
     }),
-    /* @__PURE__ */ jsxDEV("div", { className: "relative z-10 w-full h-full flex flex-col items-center justify-center text-white", children: [
-      /* @__PURE__ */ jsxDEV("h2", { className: "text-4xl font-bold text-yellow-400 mb-4", children: "Loading Game Assets..." }, void 0, false, {
-        fileName: "<stdin>",
-        lineNumber: 16,
-        columnNumber: 17
-      }),
-      /* @__PURE__ */ jsxDEV("div", { className: "w-1/2 max-w-2xl bg-gray-700 rounded-full h-8 border-2 border-gray-600", children: /* @__PURE__ */ jsxDEV(
-        "div",
-        {
-          className: "bg-yellow-500 h-full rounded-full text-center text-black font-bold leading-8 transition-all duration-500 ease-out",
-          style: { width: `${progress}%` },
-          children: /* @__PURE__ */ jsxDEV(
-            "span",
-            {
-              role: "status",
-              "aria-live": "polite",
-              children: [
-                progress,
-                "%"
-              ]
-            },
-            void 0,
-            true,
-            {
-              fileName: "<stdin>",
-              lineNumber: 21,
-              columnNumber: 25
-            }
-          )
-        },
-        void 0,
-        true,
-        {
-          fileName: "<stdin>",
-          lineNumber: 18,
-          columnNumber: 21
-        }
-      ) }, void 0, false, {
-        fileName: "<stdin>",
-        lineNumber: 17,
-        columnNumber: 17
-      }),
-      /* @__PURE__ */ jsxDEV("p", { className: "mt-4 text-gray-200", children: "Please wait, this may take a moment." }, void 0, false, {
-        fileName: "<stdin>",
-        lineNumber: 25,
-        columnNumber: 17
-      }),
-      /* @__PURE__ */ jsxDEV("p", { className: "text-xs text-gray-300 mt-2 opacity-80", children: "Tip: If performance is low, lower Render Scale in Settings." }, void 0, false, {
-        fileName: "<stdin>",
-        lineNumber: 26,
-        columnNumber: 17
-      })
-    ] }, void 0, true, {
-      fileName: "<stdin>",
-      lineNumber: 15,
-      columnNumber: 13
-    })
-  ] }, void 0, true, {
-    fileName: "<stdin>",
-    lineNumber: 5,
-    columnNumber: 9
-  });
+    [prefersReducedMotion, progress]
+  );
+
+  return (
+    <div className="w-full h-full relative">
+      <div
+        className="absolute inset-0 bg-cover bg-center"
+        style={{ backgroundImage: "url('/loading1.png')" }}
+      />
+      <div className="absolute inset-0 bg-black bg-opacity-60" />
+      <div className="relative z-10 w-full h-full flex flex-col items-center justify-center text-white">
+        <h2 className="text-4xl font-bold text-yellow-400 mb-4">Loading Game Assets...</h2>
+        <div className="w-1/2 max-w-2xl bg-gray-700 rounded-full h-8 border-2 border-gray-600">
+          <div className={progressBarClasses} style={progressBarStyle}>
+            <span role="status" aria-live="polite">
+              {progress}%
+            </span>
+          </div>
+        </div>
+        <p className="mt-4 text-gray-200">Please wait, this may take a moment.</p>
+        <p className="text-xs text-gray-300 mt-2 opacity-80">
+          Tip: If performance is low, lower Render Scale in Settings.
+        </p>
+      </div>
+    </div>
+  );
 };
-var stdin_default = LoadingScreen;
-export {
-  LoadingScreen,
-  stdin_default as default
-};
+
+export default LoadingScreen;
+export { LoadingScreen };


### PR DESCRIPTION
## Summary
- add detection for the reduced-motion media query to the loading screen progress bar
- remove the transition animation when reduced motion is requested while preserving the width updates

## Testing
- `node --input-type=module <<'NODE'\nimport React from "react";\nimport { renderToString } from "react-dom/server";\n\nglobal.window = {\n  matchMedia: () => ({\n    matches: false,\n    addEventListener() {},\n    removeEventListener() {},\n    addListener() {},\n    removeListener() {}\n  })\n};\n\nconst { default: LoadingScreen } = await import("./.tmp/loading-screen.mjs");\nconst html = renderToString(React.createElement(LoadingScreen, { progress: 50 }));\nconsole.log(html.includes("transition-all"));\nNODE`
- `node --input-type=module <<'NODE'\nimport React from "react";\nimport { renderToString } from "react-dom/server";\n\nglobal.window = {\n  matchMedia: () => ({\n    matches: true,\n    addEventListener() {},\n    removeEventListener() {},\n    addListener() {},\n    removeListener() {}\n  })\n};\n\nconst { default: LoadingScreen } = await import("./.tmp/loading-screen.mjs");\nconst html = renderToString(React.createElement(LoadingScreen, { progress: 50 }));\nconsole.log({ hasTransitionClass: html.includes("transition-all"), hasInlineNone: html.includes("transition:none") });\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_68cd96b78290833285904032030bc43e