### PR TITLE
Remove unused useEffect import from InventoryPanel

### DIFF
--- a/src/components/UI/InventoryPanel.jsx
+++ b/src/components/UI/InventoryPanel.jsx
@@ -1,5 +1,5 @@
 import { jsxDEV } from "react/jsx-dev-runtime";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { EquipmentSlot } from "./inventory/EquipmentSlot.jsx";
 import { PotionSlot } from "./inventory/PotionSlot.jsx";
 import { StorageSlot } from "./inventory/StorageSlot.jsx";


### PR DESCRIPTION
## Summary
- remove the unused useEffect hook from InventoryPanel to eliminate the warning about unused imports

## Testing
- npm run lint (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68cd96cb3d348332b3845ad0935771e5