### PR TITLE
Improve accessibility of main menu dialogs

### DIFF
--- a/src/components/UI/MainMenu.jsx
+++ b/src/components/UI/MainMenu.jsx
@@ -159,7 +159,7 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
             className: "fixed inset-0 z-50 flex items-center justify-center",
             role: "dialog",
             "aria-modal": "true",
-            "aria-label": "Map Editor",
+            "aria-labelledby": "map-editor-title",
             children: [
               /* @__PURE__ */ jsxDEV(
                 "div",
@@ -185,6 +185,11 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
                     height: `${MAP_MODAL_HEIGHT_PCT}vh`
                   },
                   children: [
+                    /* @__PURE__ */ jsxDEV("h2", { id: "map-editor-title", className: "sr-only", children: "Map Editor" }, void 0, false, {
+                      fileName: "<stdin>",
+                      lineNumber: 100,
+                      columnNumber: 21
+                    }),
                     /* @__PURE__ */ jsxDEV("div", { className: "absolute top-2 right-2 z-10", children: /* @__PURE__ */ jsxDEV(
                       "button",
                       {
@@ -241,7 +246,7 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
             columnNumber: 15
           }
         ),
-        showWelcome && /* @__PURE__ */ jsxDEV("div", { className: "fixed inset-0 z-50 flex items-center justify-center", children: [
+        showWelcome && /* @__PURE__ */ jsxDEV("div", { className: "fixed inset-0 z-50 flex items-center justify-center", role: "dialog", "aria-modal": "true", "aria-labelledby": "welcome-dialog-title", children: [
           /* @__PURE__ */ jsxDEV("div", { className: "absolute inset-0 bg-black/70", onClick: () => setShowWelcome(false) }, void 0, false, {
             fileName: "<stdin>",
             lineNumber: 124,
@@ -249,7 +254,7 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
           }),
           /* @__PURE__ */ jsxDEV("div", { className: "relative bg-gray-900 text-white border-2 border-yellow-600 rounded-xl shadow-2xl w-[95vw] max-w-[700px] p-6", children: [
             /* @__PURE__ */ jsxDEV("div", { className: "flex items-center justify-between mb-3", children: [
-              /* @__PURE__ */ jsxDEV("h2", { className: "text-yellow-400 font-bold text-xl", children: "Welcome to Naruto RPG \u2014 Early Alpha" }, void 0, false, {
+              /* @__PURE__ */ jsxDEV("h2", { id: "welcome-dialog-title", className: "text-yellow-400 font-bold text-xl", children: "Welcome to Naruto RPG \u2014 Early Alpha" }, void 0, false, {
                 fileName: "<stdin>",
                 lineNumber: 127,
                 columnNumber: 21
@@ -309,7 +314,7 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
           lineNumber: 123,
           columnNumber: 15
         }),
-        showHints && /* @__PURE__ */ jsxDEV("div", { className: "fixed inset-0 z-50 flex items-center justify-center", children: [
+        showHints && /* @__PURE__ */ jsxDEV("div", { className: "fixed inset-0 z-50 flex items-center justify-center", role: "dialog", "aria-modal": "true", "aria-labelledby": "hints-dialog-title", children: [
           /* @__PURE__ */ jsxDEV("div", { className: "absolute inset-0 bg-black/70", onClick: () => setShowHints(false) }, void 0, false, {
             fileName: "<stdin>",
             lineNumber: 144,
@@ -317,7 +322,7 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
           }),
           /* @__PURE__ */ jsxDEV("div", { className: "relative bg-gray-900 text-white border-2 border-yellow-600 rounded-xl shadow-2xl w-[90vw] max-w-[520px] p-5", children: [
             /* @__PURE__ */ jsxDEV("div", { className: "flex items-center justify-between mb-2", children: [
-              /* @__PURE__ */ jsxDEV("h2", { className: "text-yellow-400 font-bold", children: "Hints" }, void 0, false, {
+              /* @__PURE__ */ jsxDEV("h2", { id: "hints-dialog-title", className: "text-yellow-400 font-bold", children: "Hints" }, void 0, false, {
                 fileName: "<stdin>",
                 lineNumber: 146,
                 columnNumber: 75


### PR DESCRIPTION
## Summary
- expose dialog semantics on the map editor, welcome, and hints overlays
- associate each dialog with an internal heading via aria-labelledby for clearer labelling
- add a hidden heading for the map editor overlay so the dialog name is announced

## Testing
- not run (no automated accessibility tooling available in repository)

------
https://chatgpt.com/codex/tasks/task_e_68cd96ca01d0833299c9881c816111e6