### PR TITLE
Enable left click to use inventory potions

### DIFF
--- a/src/components/UI/inventory/PotionSlot.jsx
+++ b/src/components/UI/inventory/PotionSlot.jsx
@@ -19,7 +19,7 @@ const PotionSlotBase = ({ potion, onMouseEnter, onMouseLeave, onItemUse }) => /*
           tabIndex: 0,
           "aria-label": `Potion ${potion?.type || ""} (${potion?.color || ""}). Right-click to use`,
           className: "w-14 h-18 bg-gradient-to-b from-gray-700 to-gray-800 border-2 border-yellow-600 rounded-lg flex flex-col items-center justify-end cursor-pointer hover:border-yellow-400 transition-all duration-200 relative overflow-hidden",
-          onClick: () => console.log("Left-click on potion. Hint: Right-click to use."),
+          onClick: () => onItemUse(potion),
           onKeyDown: (e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();


### PR DESCRIPTION
## Summary
- call the provided onItemUse handler when the potion slot is left-clicked
- retain right-click and keyboard handling while enabling the existing consumption logic

## Testing
- `node <<'NODE'
import { PotionSlot } from './tmpPotionSlot.mjs';
const potion = { type: 'healing', color: 'red', count: 2 };
let usedPotion = null;
const element = PotionSlot.type({
  potion,
  onMouseEnter: () => {},
  onMouseLeave: () => {},
  onItemUse: (item) => {
    usedPotion = item;
    item.count -= 1;
  }
});
const clickableDiv = Array.isArray(element.props.children)
  ? element.props.children[0]
  : element.props.children;
clickableDiv.props.onClick();
if (usedPotion !== potion) {
  throw new Error('Potion was not passed correctly to onItemUse');
}
if (potion.count !== 1) {
  throw new Error('Potion count did not decrease');
}
console.log('Left-click test passed');
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68cd9b8074ec83328dd4e2b314618d33