### PR TITLE
Highlight invalid inventory drop targets

### DIFF
--- a/src/components/UI/InventoryPanel.jsx
+++ b/src/components/UI/InventoryPanel.jsx
@@ -192,7 +192,9 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
                     onMouseLeave: handleMouseLeave,
                     onDrop: handleDrop,
                     onDragStart: handleDragStart,
-                    onDragOver: (e) => handleDragOver(e, "equipment", "helmet")
+                    onDragOver: (e) => handleDragOver(e, "equipment", "helmet"),
+                    onDragLeave: () => setCanDrop(true),
+                    canDrop
                   },
                   void 0,
                   false,
@@ -212,7 +214,9 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
                     onMouseLeave: handleMouseLeave,
                     onDrop: handleDrop,
                     onDragStart: handleDragStart,
-                    onDragOver: (e) => handleDragOver(e, "equipment", "weapon")
+                    onDragOver: (e) => handleDragOver(e, "equipment", "weapon"),
+                    onDragLeave: () => setCanDrop(true),
+                    canDrop
                   },
                   void 0,
                   false,
@@ -232,7 +236,9 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
                     onMouseLeave: handleMouseLeave,
                     onDrop: handleDrop,
                     onDragStart: handleDragStart,
-                    onDragOver: (e) => handleDragOver(e, "equipment", "shield")
+                    onDragOver: (e) => handleDragOver(e, "equipment", "shield"),
+                    onDragLeave: () => setCanDrop(true),
+                    canDrop
                   },
                   void 0,
                   false,
@@ -253,7 +259,9 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
                     onMouseLeave: handleMouseLeave,
                     onDrop: handleDrop,
                     onDragStart: handleDragStart,
-                    onDragOver: (e) => handleDragOver(e, "equipment", "armor")
+                    onDragOver: (e) => handleDragOver(e, "equipment", "armor"),
+                    onDragLeave: () => setCanDrop(true),
+                    canDrop
                   },
                   void 0,
                   false,
@@ -273,7 +281,9 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
                     onMouseLeave: handleMouseLeave,
                     onDrop: handleDrop,
                     onDragStart: handleDragStart,
-                    onDragOver: (e) => handleDragOver(e, "equipment", "gloves")
+                    onDragOver: (e) => handleDragOver(e, "equipment", "gloves"),
+                    onDragLeave: () => setCanDrop(true),
+                    canDrop
                   },
                   void 0,
                   false,
@@ -293,7 +303,9 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
                     onMouseLeave: handleMouseLeave,
                     onDrop: handleDrop,
                     onDragStart: handleDragStart,
-                    onDragOver: (e) => handleDragOver(e, "equipment", "boots")
+                    onDragOver: (e) => handleDragOver(e, "equipment", "boots"),
+                    onDragLeave: () => setCanDrop(true),
+                    canDrop
                   },
                   void 0,
                   false,
@@ -314,7 +326,9 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
                     onMouseLeave: handleMouseLeave,
                     onDrop: handleDrop,
                     onDragStart: handleDragStart,
-                    onDragOver: (e) => handleDragOver(e, "equipment", "ring1")
+                    onDragOver: (e) => handleDragOver(e, "equipment", "ring1"),
+                    onDragLeave: () => setCanDrop(true),
+                    canDrop
                   },
                   void 0,
                   false,
@@ -335,7 +349,9 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
                     onMouseLeave: handleMouseLeave,
                     onDrop: handleDrop,
                     onDragStart: handleDragStart,
-                    onDragOver: (e) => handleDragOver(e, "equipment", "ring2")
+                    onDragOver: (e) => handleDragOver(e, "equipment", "ring2"),
+                    onDragLeave: () => setCanDrop(true),
+                    canDrop
                   },
                   void 0,
                   false,
@@ -356,7 +372,9 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
                     onMouseLeave: handleMouseLeave,
                     onDrop: handleDrop,
                     onDragStart: handleDragStart,
-                    onDragOver: (e) => handleDragOver(e, "equipment", "amulet")
+                    onDragOver: (e) => handleDragOver(e, "equipment", "amulet"),
+                    onDragLeave: () => setCanDrop(true),
+                    canDrop
                   },
                   void 0,
                   false,
@@ -423,7 +441,7 @@ const InventoryPanel = ({ inventory, setInventory, onClose }) => {
               lineNumber: 254,
               columnNumber: 13
             }),
-            /* @__PURE__ */ jsxDEV("div", { className: "grid grid-cols-8 gap-2 mb-4", style: { height: "380px", alignContent: "start" }, onDragOver: (e) => handleDragOver(e, "storage", null), children: inventory.storage.map((item, index) => /* @__PURE__ */ jsxDEV(StorageSlot, { item, index, onMouseEnter: handleMouseEnter, onMouseLeave: handleMouseLeave, onDrop: handleDrop, onDragStart: handleDragStart }, index, false, {
+            /* @__PURE__ */ jsxDEV("div", { className: "grid grid-cols-8 gap-2 mb-4", style: { height: "380px", alignContent: "start" }, onDragOver: (e) => handleDragOver(e, "storage", null), children: inventory.storage.map((item, index) => /* @__PURE__ */ jsxDEV(StorageSlot, { item, index, onMouseEnter: handleMouseEnter, onMouseLeave: handleMouseLeave, onDrop: handleDrop, onDragStart: handleDragStart, canDrop, onDragLeave: () => setCanDrop(true), onDragOver: (e) => handleDragOver(e, "storage", index) }, index, false, {
               fileName: "<stdin>",
               lineNumber: 263,
               columnNumber: 17

--- a/src/components/UI/inventory/EquipmentSlot.jsx
+++ b/src/components/UI/inventory/EquipmentSlot.jsx
@@ -1,66 +1,118 @@
 import { Fragment, jsxDEV } from "react/jsx-dev-runtime";
-import React from "react";
+import React, { useState } from "react";
 import { getSlotRarityColor } from "./utils.js";
-const EquipmentSlot = ({ slotName, item, position, size = "w-16 h-16", onMouseEnter, onMouseLeave, onDrop, onDragStart }) => /* @__PURE__ */ jsxDEV("div", { className: `${position} group`, children: /* @__PURE__ */ jsxDEV(
-  "div",
-  {
-    className: `${size} bg-gradient-to-br from-gray-800 to-gray-900 border-2 ${item ? getSlotRarityColor(item.rarity) : "border-gray-600"} rounded-lg flex items-center justify-center cursor-pointer hover:border-yellow-500 transition-all duration-200 relative overflow-hidden`,
-    onMouseEnter: (e) => onMouseEnter(item, e),
-    onMouseLeave,
-    onDrop: (e) => onDrop(e, "equipment", slotName),
-    onDragOver: (e) => e.preventDefault(),
-    children: [
-      item ? /* @__PURE__ */ jsxDEV(Fragment, { children: [
-        /* @__PURE__ */ jsxDEV(
-          "div",
-          {
-            draggable: true,
-            onDragStart: (e) => onDragStart(e, item, "equipment", slotName),
-            className: "text-3xl cursor-move hover:scale-110 transition-transform duration-200 relative z-10",
-            title: item.name,
-            children: item.icon
-          },
-          void 0,
-          false,
-          {
+const EquipmentSlot = ({
+  slotName,
+  item,
+  position,
+  size = "w-16 h-16",
+  onMouseEnter,
+  onMouseLeave,
+  onDrop,
+  onDragStart,
+  onDragOver,
+  onDragLeave,
+  canDrop
+}) => {
+  const [isDragOver, setIsDragOver] = useState(false);
+  const isInvalidTarget = isDragOver && canDrop === false;
+  const borderColorClass = isInvalidTarget ? "border-red-500" : item ? getSlotRarityColor(item.rarity) : "border-gray-600";
+  const invalidDropClasses = isInvalidTarget ? "invalid-drop-shake" : "";
+  const invalidDropStyle = isInvalidTarget ? { boxShadow: "0 0 14px rgba(248, 113, 113, 0.55)" } : void 0;
+  const handleDragEnter = (e) => {
+    e.preventDefault();
+    setIsDragOver(true);
+    if (onDragOver) {
+      onDragOver(e);
+    }
+  };
+  const handleDragOver = (e) => {
+    e.preventDefault();
+    if (!isDragOver) {
+      setIsDragOver(true);
+    }
+    if (onDragOver) {
+      onDragOver(e);
+    }
+  };
+  const handleDragLeave = (e) => {
+    if (e.currentTarget.contains(e.relatedTarget)) {
+      return;
+    }
+    setIsDragOver(false);
+    if (onDragLeave) {
+      onDragLeave(e);
+    }
+  };
+  const handleDrop = (e) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    onDrop(e, "equipment", slotName);
+  };
+  return /* @__PURE__ */ jsxDEV("div", { className: `${position} group`, children: /* @__PURE__ */ jsxDEV(
+    "div",
+    {
+      className: `${size} bg-gradient-to-br from-gray-800 to-gray-900 border-2 ${borderColorClass} ${invalidDropClasses} rounded-lg flex items-center justify-center cursor-pointer hover:border-yellow-500 transition-all duration-200 relative overflow-hidden`,
+      style: invalidDropStyle,
+      onMouseEnter: (e) => onMouseEnter(item, e),
+      onMouseLeave,
+      onDrop: handleDrop,
+      onDragEnter: handleDragEnter,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      children: [
+        item ? /* @__PURE__ */ jsxDEV(Fragment, { children: [
+          /* @__PURE__ */ jsxDEV(
+            "div",
+            {
+              draggable: true,
+              onDragStart: (e) => onDragStart(e, item, "equipment", slotName),
+              className: "text-3xl cursor-move hover:scale-110 transition-transform duration-200 relative z-10",
+              title: item.name,
+              children: item.icon
+            },
+            void 0,
+            false,
+            {
+              fileName: "<stdin>",
+              lineNumber: 45,
+              columnNumber: 13
+            }
+          ),
+          item.durability && item.durability.current < item.durability.max * 0.3 && /* @__PURE__ */ jsxDEV("div", { className: "absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full animate-pulse" }, void 0, false, {
             fileName: "<stdin>",
-            lineNumber: 17,
-            columnNumber: 13
-          }
-        ),
-        item.durability && item.durability.current < item.durability.max * 0.3 && /* @__PURE__ */ jsxDEV("div", { className: "absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full animate-pulse" }, void 0, false, {
+            lineNumber: 54,
+            columnNumber: 15
+          })
+        ] }, void 0, true, {
           fileName: "<stdin>",
-          lineNumber: 26,
-          columnNumber: 15
+          lineNumber: 44,
+          columnNumber: 11
+        }) : /* @__PURE__ */ jsxDEV("div", { className: "text-gray-500 text-xs text-center font-semibold uppercase tracking-wider", children: slotName }, void 0, false, {
+          fileName: "<stdin>",
+          lineNumber: 58,
+          columnNumber: 11
+        }),
+        item && (item.rarity === "epic" || item.rarity === "legendary") && /* @__PURE__ */ jsxDEV("div", { className: "absolute inset-0 bg-gradient-to-br from-transparent via-white to-transparent opacity-10 animate-pulse" }, void 0, false, {
+          fileName: "<stdin>",
+          lineNumber: 65,
+          columnNumber: 11
         })
-      ] }, void 0, true, {
-        fileName: "<stdin>",
-        lineNumber: 16,
-        columnNumber: 11
-      }) : /* @__PURE__ */ jsxDEV("div", { className: "text-gray-500 text-xs text-center font-semibold uppercase tracking-wider", children: slotName }, void 0, false, {
-        fileName: "<stdin>",
-        lineNumber: 30,
-        columnNumber: 11
-      }),
-      item && (item.rarity === "epic" || item.rarity === "legendary") && /* @__PURE__ */ jsxDEV("div", { className: "absolute inset-0 bg-gradient-to-br from-transparent via-white to-transparent opacity-10 animate-pulse" }, void 0, false, {
-        fileName: "<stdin>",
-        lineNumber: 37,
-        columnNumber: 11
-      })
-    ]
-  },
-  void 0,
-  true,
-  {
+      ]
+    },
+    void 0,
+    true,
+    {
+      fileName: "<stdin>",
+      lineNumber: 36,
+      columnNumber: 7
+    }
+  ) }, void 0, false, {
     fileName: "<stdin>",
-    lineNumber: 6,
-    columnNumber: 7
-  }
-) }, void 0, false, {
-  fileName: "<stdin>",
-  lineNumber: 5,
-  columnNumber: 5
-});
+    lineNumber: 35,
+    columnNumber: 5
+  });
+};
 export {
   EquipmentSlot
 };

--- a/src/components/UI/inventory/StorageSlot.jsx
+++ b/src/components/UI/inventory/StorageSlot.jsx
@@ -1,68 +1,118 @@
 import { Fragment, jsxDEV } from "react/jsx-dev-runtime";
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { getSlotRarityColor } from "./utils.js";
-const StorageSlotBase = ({ item, index, onMouseEnter, onMouseLeave, onDrop, onDragStart }) => /* @__PURE__ */ jsxDEV(
-  "div",
-  {
-    className: `w-14 h-14 bg-gradient-to-br from-gray-700 to-gray-800 border ${item ? `${getSlotRarityColor(item.rarity)} hover:border-yellow-400` : "border-gray-600 hover:border-gray-500"} rounded-md flex items-center justify-center cursor-pointer transition-all duration-200 relative group`,
-    onMouseEnter: (e) => onMouseEnter(item, e),
-    onMouseLeave,
-    onDrop: (e) => onDrop(e, "storage", index),
-    onDragOver: (e) => e.preventDefault(),
-    children: item ? /* @__PURE__ */ jsxDEV(Fragment, { children: [
-      /* @__PURE__ */ jsxDEV(
-        "div",
-        {
-          draggable: true,
-          onDragStart: (e) => onDragStart(e, item, "storage", index),
-          role: "button",
-          tabIndex: 0,
-          "aria-label": `${item?.name || "Item"} slot ${index + 1}. Drag to move`,
-          className: "text-2xl cursor-move hover:scale-110 transition-transform duration-200 relative z-10",
-          onKeyDown: (e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-            }
+const StorageSlotBase = ({
+  item,
+  index,
+  onMouseEnter,
+  onMouseLeave,
+  onDrop,
+  onDragStart,
+  canDrop,
+  onDragOver,
+  onDragLeave
+}) => {
+  const [isDragOver, setIsDragOver] = useState(false);
+  const isInvalidTarget = isDragOver && canDrop === false;
+  const borderColorClass = isInvalidTarget ? "border-red-500" : item ? `${getSlotRarityColor(item.rarity)} hover:border-yellow-400` : "border-gray-600 hover:border-gray-500";
+  const invalidDropClasses = isInvalidTarget ? "invalid-drop-shake" : "";
+  const invalidDropStyle = isInvalidTarget ? { boxShadow: "0 0 12px rgba(248, 113, 113, 0.5)" } : void 0;
+  const handleDragEnter = (e) => {
+    e.preventDefault();
+    setIsDragOver(true);
+    if (onDragOver) {
+      onDragOver(e);
+    }
+  };
+  const handleDragOver = (e) => {
+    e.preventDefault();
+    if (!isDragOver) {
+      setIsDragOver(true);
+    }
+    if (onDragOver) {
+      onDragOver(e);
+    }
+  };
+  const handleDragLeave = (e) => {
+    if (e.currentTarget.contains(e.relatedTarget)) {
+      return;
+    }
+    setIsDragOver(false);
+    if (onDragLeave) {
+      onDragLeave(e);
+    }
+  };
+  const handleDrop = (e) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    onDrop(e, "storage", index);
+  };
+  return /* @__PURE__ */ jsxDEV(
+    "div",
+    {
+      className: `w-14 h-14 bg-gradient-to-br from-gray-700 to-gray-800 border ${borderColorClass} ${invalidDropClasses} rounded-md flex items-center justify-center cursor-pointer transition-all duration-200 relative group`,
+      style: invalidDropStyle,
+      onMouseEnter: (e) => onMouseEnter(item, e),
+      onMouseLeave,
+      onDrop: handleDrop,
+      onDragEnter: handleDragEnter,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      children: item ? /* @__PURE__ */ jsxDEV(Fragment, { children: [
+        /* @__PURE__ */ jsxDEV(
+          "div",
+          {
+            draggable: true,
+            onDragStart: (e) => onDragStart(e, item, "storage", index),
+            role: "button",
+            tabIndex: 0,
+            "aria-label": `${item?.name || "Item"} slot ${index + 1}. Drag to move`,
+            className: "text-2xl cursor-move hover:scale-110 transition-transform duration-200 relative z-10",
+            onKeyDown: (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+              }
+            },
+            children: item.icon
           },
-          children: item.icon
-        },
-        void 0,
-        false,
-        {
+          void 0,
+          false,
+          {
+            fileName: "<stdin>",
+            lineNumber: 37,
+            columnNumber: 11
+          }
+        ),
+        item.count > 1 && /* @__PURE__ */ jsxDEV("div", { className: "absolute -bottom-1 -right-1 bg-gray-900 text-yellow-400 rounded-full w-5 h-5 flex items-center justify-center text-xs font-bold border border-yellow-600", children: item.count > 999 ? "999+" : item.count }, void 0, false, {
           fileName: "<stdin>",
-          lineNumber: 16,
-          columnNumber: 11
-        }
-      ),
-      item.count > 1 && /* @__PURE__ */ jsxDEV("div", { className: "absolute -bottom-1 -right-1 bg-gray-900 text-yellow-400 rounded-full w-5 h-5 flex items-center justify-center text-xs font-bold border border-yellow-600", children: item.count > 999 ? "999+" : item.count }, void 0, false, {
+          lineNumber: 45,
+          columnNumber: 13
+        }),
+        item.rarity === "legendary" && /* @__PURE__ */ jsxDEV("div", { className: "absolute inset-0 bg-gradient-to-br from-yellow-400 to-transparent opacity-20 rounded-md animate-pulse" }, void 0, false, {
+          fileName: "<stdin>",
+          lineNumber: 52,
+          columnNumber: 13
+        })
+      ] }, void 0, true, {
         fileName: "<stdin>",
-        lineNumber: 24,
-        columnNumber: 13
-      }),
-      item.rarity === "legendary" && /* @__PURE__ */ jsxDEV("div", { className: "absolute inset-0 bg-gradient-to-br from-yellow-400 to-transparent opacity-20 rounded-md animate-pulse" }, void 0, false, {
+        lineNumber: 36,
+        columnNumber: 9
+      }) : /* @__PURE__ */ jsxDEV("div", { className: "w-full h-full rounded-md bg-gradient-to-br from-gray-800 to-gray-900" }, void 0, false, {
         fileName: "<stdin>",
-        lineNumber: 31,
-        columnNumber: 13
+        lineNumber: 56,
+        columnNumber: 9
       })
-    ] }, void 0, true, {
+    },
+    void 0,
+    false,
+    {
       fileName: "<stdin>",
-      lineNumber: 15,
-      columnNumber: 9
-    }) : /* @__PURE__ */ jsxDEV("div", { className: "w-full h-full rounded-md bg-gradient-to-br from-gray-800 to-gray-900" }, void 0, false, {
-      fileName: "<stdin>",
-      lineNumber: 35,
-      columnNumber: 9
-    })
-  },
-  void 0,
-  false,
-  {
-    fileName: "<stdin>",
-    lineNumber: 5,
-    columnNumber: 5
-  }
-);
+      lineNumber: 27,
+      columnNumber: 5
+    }
+  );
+};
 StorageSlotBase.propTypes = {
   item: PropTypes.shape({
     name: PropTypes.string,
@@ -74,7 +124,10 @@ StorageSlotBase.propTypes = {
   onMouseEnter: PropTypes.func.isRequired,
   onMouseLeave: PropTypes.func,
   onDrop: PropTypes.func.isRequired,
-  onDragStart: PropTypes.func.isRequired
+  onDragStart: PropTypes.func.isRequired,
+  canDrop: PropTypes.bool,
+  onDragOver: PropTypes.func,
+  onDragLeave: PropTypes.func
 };
 const StorageSlot = React.memo(StorageSlotBase);
 export {

--- a/styles/style.css
+++ b/styles/style.css
@@ -9,3 +9,23 @@ html, body {
   background-position: center;
   background-repeat: no-repeat;
 }
+
+@keyframes inventory-slot-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-3px);
+  }
+  50% {
+    transform: translateX(3px);
+  }
+  75% {
+    transform: translateX(-2px);
+  }
+}
+
+.invalid-drop-shake {
+  animation: inventory-slot-shake 0.35s ease-in-out;
+}


### PR DESCRIPTION
## Summary
- pass the drag-and-drop validation state to each equipment and storage slot so they can react to invalid targets
- add per-slot drag over handling that shows a red border and shake animation when an item cannot be dropped
- define a reusable shake keyframe animation for invalid drop feedback

## Testing
- npm run dev *(fails: missing server.mjs entry point)*

------
https://chatgpt.com/codex/tasks/task_e_68cda1a118c48332a6c686ba96c33df5