### PR TITLE
Persist HUD controls visibility

### DIFF
--- a/src/components/UI/HUD.jsx
+++ b/src/components/UI/HUD.jsx
@@ -5,12 +5,28 @@ import { PlayerInfo } from "./hud/PlayerInfo.jsx";
 import { ControlsInfo } from "./hud/ControlsInfo.jsx";
 import { Minimap } from "./hud/Minimap.jsx";
 import { Compass } from "./hud/Compass.jsx";
+const CONTROLS_STORAGE_KEY = "hud.showControlsInfo";
 const HUDComponent = ({ playerStats, playerRef, worldObjects, zoomRef, settings }) => {
-  const [showControlsInfo, setShowControlsInfo] = useState(true);
+  const [showControlsInfo, setShowControlsInfo] = useState(() => {
+    if (typeof window === "undefined") {
+      return true;
+    }
+    const storedValue = window.localStorage.getItem(CONTROLS_STORAGE_KEY);
+    return storedValue === null ? true : storedValue === "true";
+  });
   useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.localStorage.setItem(CONTROLS_STORAGE_KEY, showControlsInfo ? "true" : "false");
+  }, [showControlsInfo]);
+  useEffect(() => {
+    if (!showControlsInfo) {
+      return;
+    }
     const t = setTimeout(() => setShowControlsInfo(false), 1e4);
     return () => clearTimeout(t);
-  }, []);
+  }, [showControlsInfo]);
   return /* @__PURE__ */ jsxDEV(Fragment, { children: [
     /* Left top cluster */
     /* Player info + Controls modal */


### PR DESCRIPTION
## Summary
- load the HUD controls visibility preference from local storage on mount
- persist changes to the visibility flag whenever the user shows or hides the panel
- rerun the auto-hide timer only while the controls are visible

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cda493157c8332abcc14ff0ee72339