### PR TITLE
Compute inventory stats dynamically

### DIFF
--- a/src/components/UI/inventory/InventoryStats.jsx
+++ b/src/components/UI/inventory/InventoryStats.jsx
@@ -1,9 +1,13 @@
 import { jsxDEV } from "react/jsx-dev-runtime";
 import React from "react";
+import { computeInventoryStats } from "./inventoryUtils.js";
 const InventoryStats = ({ inventory }) => {
-  const weight = 127;
+  const { totalWeight, totalValue, conditionPercentage } = computeInventoryStats(inventory);
   const maxWeight = 200;
-  const value = 2847;
+  const weightPercentage = maxWeight > 0 ? Math.min(100, totalWeight / maxWeight * 100) : 0;
+  const weightDisplay = totalWeight.toLocaleString(void 0, { maximumFractionDigits: 1 });
+  const formattedValue = totalValue.toLocaleString();
+  const qualityDisplay = conditionPercentage !== null ? `${conditionPercentage}%` : "N/A";
   return /* @__PURE__ */ jsxDEV("div", { className: "bg-gray-800 bg-opacity-70 border border-yellow-500 rounded-lg p-3", children: /* @__PURE__ */ jsxDEV("div", { className: "grid grid-cols-3 gap-4 text-sm", children: [
     /* @__PURE__ */ jsxDEV("div", { children: [
       /* @__PURE__ */ jsxDEV("div", { className: "flex justify-between text-yellow-300 mb-1", children: [
@@ -13,7 +17,7 @@ const InventoryStats = ({ inventory }) => {
           columnNumber: 17
         }),
         /* @__PURE__ */ jsxDEV("span", { children: [
-          weight,
+          weightDisplay,
           "/",
           maxWeight
         ] }, void 0, true, {
@@ -26,7 +30,7 @@ const InventoryStats = ({ inventory }) => {
         lineNumber: 13,
         columnNumber: 15
       }),
-      /* @__PURE__ */ jsxDEV("div", { className: "w-full bg-gray-700 rounded-full h-2", children: /* @__PURE__ */ jsxDEV("div", { className: "bg-blue-500 h-2 rounded-full", style: { width: `${weight / maxWeight * 100}%` } }, void 0, false, {
+      /* @__PURE__ */ jsxDEV("div", { className: "w-full bg-gray-700 rounded-full h-2", children: /* @__PURE__ */ jsxDEV("div", { className: "bg-blue-500 h-2 rounded-full", style: { width: `${weightPercentage}%` } }, void 0, false, {
         fileName: "<stdin>",
         lineNumber: 18,
         columnNumber: 17
@@ -48,7 +52,7 @@ const InventoryStats = ({ inventory }) => {
           columnNumber: 17
         }),
         /* @__PURE__ */ jsxDEV("span", { children: [
-          value,
+          formattedValue,
           " Gold"
         ] }, void 0, true, {
           fileName: "<stdin>",
@@ -77,7 +81,7 @@ const InventoryStats = ({ inventory }) => {
           lineNumber: 30,
           columnNumber: 17
         }),
-        /* @__PURE__ */ jsxDEV("span", { children: "Good" }, void 0, false, {
+        /* @__PURE__ */ jsxDEV("span", { children: qualityDisplay }, void 0, false, {
           fileName: "<stdin>",
           lineNumber: 31,
           columnNumber: 17

--- a/src/components/UI/inventory/inventoryUtils.js
+++ b/src/components/UI/inventory/inventoryUtils.js
@@ -1,0 +1,69 @@
+export const computeInventoryStats = (inventory) => {
+  const initialStats = {
+    totalWeight: 0,
+    totalValue: 0,
+    averageCondition: null,
+    conditionPercentage: null
+  };
+
+  if (!inventory || typeof inventory !== "object") {
+    return initialStats;
+  }
+
+  let totalWeight = 0;
+  let totalValue = 0;
+  let conditionSum = 0;
+  let conditionCount = 0;
+
+  const extractNumeric = (...values) => {
+    for (const value of values) {
+      if (typeof value === "number" && !Number.isNaN(value)) {
+        return value;
+      }
+    }
+    return 0;
+  };
+
+  const addItemStats = (item) => {
+    if (!item) return;
+
+    const quantity = typeof item.count === "number" && item.count > 0 ? item.count : 1;
+    const itemWeight = extractNumeric(item.weight, item.stats?.weight);
+    const itemValue = extractNumeric(item.value, item.stats?.value, item.cost, item.price);
+
+    if (itemWeight > 0) {
+      totalWeight += itemWeight * quantity;
+    }
+
+    if (itemValue > 0) {
+      totalValue += itemValue * quantity;
+    }
+
+    if (item.durability && typeof item.durability.current === "number" && typeof item.durability.max === "number" && item.durability.max > 0) {
+      conditionSum += item.durability.current / item.durability.max;
+      conditionCount += 1;
+    }
+  };
+
+  const possibleCollections = [
+    inventory.equipment && Object.values(inventory.equipment),
+    Array.isArray(inventory.potions) ? inventory.potions : null,
+    Array.isArray(inventory.storage) ? inventory.storage : null
+  ];
+
+  for (const collection of possibleCollections) {
+    if (!collection) continue;
+    for (const item of collection) {
+      addItemStats(item);
+    }
+  }
+
+  const averageCondition = conditionCount > 0 ? conditionSum / conditionCount : null;
+
+  return {
+    totalWeight,
+    totalValue,
+    averageCondition,
+    conditionPercentage: averageCondition !== null ? Math.round(averageCondition * 100) : null
+  };
+};


### PR DESCRIPTION
## Summary
- compute total weight, value, and average condition from the live inventory contents
- surface the calculated numbers in InventoryStats with formatting and resilience to empty inventories

## Testing
- node --input-type=module <<'NODE'\nimport { computeInventoryStats } from './NarutoRPG/src/components/UI/inventory/inventoryUtils.js';\n\nconst sampleInventory = {\n  equipment: {\n    sword: { name: 'Sword', stats: { weight: 5 }, value: 200, durability: { current: 40, max: 50 } },\n    shield: { name: 'Shield', stats: { weight: 8 }, cost: 150, durability: { current: 90, max: 100 } },\n    amulet: null\n  },\n  potions: [\n    { name: 'Health Potion', count: 3, weight: 0.2, price: 25 },\n    { name: 'Mana Potion', count: 1 }\n  ],\n  storage: [\n    { name: 'Gem', count: 2, value: 100 },\n    null\n  ]\n};\n\nconst stats = computeInventoryStats(sampleInventory);\nconsole.log(stats);\nNODE
- node --input-type=module <<'NODE'\nimport { computeInventoryStats } from './NarutoRPG/src/components/UI/inventory/inventoryUtils.js';\n\nconsole.log(computeInventoryStats(null));\nconsole.log(computeInventoryStats({}));\nNODE

------
https://chatgpt.com/codex/tasks/task_e_68cda5a66af88332941184bb6bdb6fdb