### PR TITLE
Improve pause menu input handling

### DIFF
--- a/src/OpenWorldGame.jsx
+++ b/src/OpenWorldGame.jsx
@@ -96,6 +96,14 @@ const OpenWorldGame = () => {
   const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0;
   const { playerRef, zoomRef, cameraOrbitRef, cameraPitchRef } = useThreeScene({ mountRef, keysRef, joystickRef, setPlayerPosition, settings, setWorldObjects, isPlaying: gameState === "Playing", onReady: useCallback(() => setGameReady(true), []) });
   const musicWasPlayingRef = useRef(false);
+  const releasePauseMenu = useCallback(() => {
+    const wasPausedBefore = window.__pauseMenuWasPausedBefore;
+    delete window.__pauseMenuActive;
+    if (!wasPausedBefore) {
+      window.__gamePaused = false;
+    }
+    delete window.__pauseMenuWasPausedBefore;
+  }, []);
   useEffect(() => {
     const open = () => {
       window.__gamePaused = true;
@@ -229,11 +237,15 @@ const OpenWorldGame = () => {
     }),
     /* NEW: Pause Menu overlay */
     gameState === "Playing" && showPauseMenu && /* @__PURE__ */ jsxDEV(PauseMenu, {
-      onResume: () => setShowPauseMenu(false),
+      onResume: () => {
+        releasePauseMenu();
+        setShowPauseMenu(false);
+      },
       onOptions: () => {
         setShowSettings(true);
       },
       onExitToMenu: () => {
+        releasePauseMenu();
         setShowPauseMenu(false);
         setShowSettings(false);
         setShowCharacter(false);

--- a/src/components/UI/ChangelogPanel.jsx
+++ b/src/components/UI/ChangelogPanel.jsx
@@ -5,7 +5,8 @@ const LATEST_DATE = "2025-09-06";
 const LATEST_CHANGES = [
   "Defaulted controls and UI to desktop-first experience.",
   "Switched Hospital model to local asset to resolve CORS issues.",
-  "Updated version labels across UI for consistency."
+  "Updated version labels across UI for consistency.",
+  "Pause menu Backquote toggle now exits pointer lock, sets a global pause flag, and suppresses gameplay input while paused."
 ];
 const changelogData = [
   { version: LATEST_VERSION, date: LATEST_DATE, changes: LATEST_CHANGES },


### PR DESCRIPTION
## Summary
- exit pointer lock and manage the global pause flag when the Backquote pause toggle runs, while ignoring gameplay input during pauses
- release the global pause flag appropriately when resuming or exiting from the pause menu
- document the pause menu behaviour change in the changelog

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdae731c1c83329753f323f370bed1