### PR TITLE
Add planned improvements roadmap modal

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,5 @@
 Recent
+- Main Menu: Added a read-only Planned Improvements modal sourced from a 50-item roadmap checklist.
 - Multiplayer: Wired the main world into Websim presence so other players spawn with synced movement, rotation, and character identity; index.html now loads the WebsimSocket client script.
 - Main Menu: Added a Showcase gallery modal that surfaces src/assets/images/showcase/ images (auto-detected, no manifest needed) and opens them full size.
 - Neji: Force his model materials to write depth so the ground no longer shows through.

--- a/planned_improvements.md
+++ b/planned_improvements.md
@@ -1,0 +1,61 @@
+# Planned Improvements Roadmap
+
+## Core Gameplay
+- [ ] Build a narrative campaign spanning six story arcs with escalating stakes and cinematic cutscenes.
+- [ ] Introduce branching mission objectives that react to player choices and squad composition.
+- [ ] Implement difficulty tiers for every mission with smarter AI and richer rewards on higher settings.
+- [ ] Add a mission grading system (S/A/B/C) that tracks time, stealth, and damage taken.
+- [ ] Create cooperative team missions that require coordinated roles and synced objectives.
+- [ ] Design stealth-focused infiltration missions with visibility cones and silent takedowns.
+- [ ] Build wave-based survival challenges that escalate enemy types and environmental hazards.
+- [ ] Construct puzzle-driven training grounds that teach advanced mechanics through environmental riddles.
+- [ ] Schedule dynamic world events that trigger invasions or defense quests on a shared timer.
+- [ ] Launch multi-squad world boss encounters with telegraphed mechanics and ranked rewards.
+
+## Combat & Skills
+- [ ] Expand melee combat with combo strings, cancels, and aerial finishers for each hero.
+- [ ] Introduce a chakra management bar that governs jutsu usage and enables burst states.
+- [ ] Develop hero-specific jutsu skill trees that unlock new abilities and passive perks.
+- [ ] Add weapon loadouts with quick swapping and upgrade paths for kunai, shuriken, and blades.
+- [ ] Implement a timed guard/parry window that opens counter-attack opportunities.
+- [ ] Simulate elemental interactions where opposing chakra natures amplify or negate damage.
+- [ ] Add companion command wheels so players can assign tactics, focus targets, or healing roles.
+- [ ] Create distinct enemy archetypes (brute, healer, striker, support) with synergy behaviors.
+- [ ] Design multi-phase boss fights with breakpoints, cinematic specials, and safe-zone telegraphs.
+- [ ] Build a dojo training mode that tracks combos, DPS, and defensive drills with scoreboards.
+
+## Progression & Economy
+- [ ] Implement character leveling with stat allocation and specialization choices.
+- [ ] Create a village reputation system that unlocks discounts, missions, and cosmetic titles.
+- [ ] Add a crafting loop using gathered resources to forge gear, potions, and talismans.
+- [ ] Refresh shop inventories with rotating stock and limited-time rare items.
+- [ ] Introduce daily and weekly missions that reward currencies and progression boosts.
+- [ ] Launch an achievement system that tracks milestones and grants account-wide perks.
+- [ ] Add collectible outfits, weapon skins, and emotes earned through gameplay milestones.
+- [ ] Enable player housing where interiors can be decorated and expanded with earned props.
+- [ ] Create a summon companion system with upgradeable contracts and battlefield roles.
+- [ ] Build a mentorship feature that pairs veterans with new players for shared rewards.
+
+## World & Exploration
+- [ ] Expand the overworld with new regions like the Sand Village, Mist Village, and borderlands.
+- [ ] Add a fast-travel scroll network unlocked by discovering landmarks.
+- [ ] Implement a full day-night cycle with NPC schedules and time-sensitive activities.
+- [ ] Simulate dynamic weather that affects visibility, traversal, and certain jutsu types.
+- [ ] Populate the world with ambient wildlife, gatherable plants, and interactive scenery.
+- [ ] Hide lore scrolls and secret collectibles that unlock codex entries and cosmetic rewards.
+- [ ] Enable wall-running, tree-leaping, and rooftop parkour with stamina and skill checks.
+- [ ] Add mini-games such as chakra races, fishing challenges, and delivery runs.
+- [ ] Introduce summonable mounts or gliders to speed up long-distance travel.
+- [ ] Design instanced hideouts and dungeons with puzzles, traps, and rare loot tables.
+
+## Social & Live Systems
+- [ ] Launch a clan system with shared bases, research trees, and clan missions.
+- [ ] Add ranked and casual PvP arenas with matchmaking and seasonal ladders.
+- [ ] Provide a spectator mode with camera tools for tournaments and player-hosted events.
+- [ ] Implement safe text and emote chat channels with moderation tools and filters.
+- [ ] Create a friend list, parties, and quick-invite flow for missions and free roam.
+- [ ] Host seasonal festivals with rotating activities, narrative beats, and exclusive loot.
+- [ ] Integrate an in-game feedback, bug report, and feature voting terminal.
+- [ ] Support cross-session cloud saves so progress persists across devices.
+- [ ] Publish official modding guidelines and a lightweight SDK for custom maps or missions.
+- [ ] Deliver an interactive academy tutorial and codex that teaches advanced mechanics.

--- a/src/components/UI/MainMenu.jsx
+++ b/src/components/UI/MainMenu.jsx
@@ -1,5 +1,6 @@
 import { jsxDEV } from "react/jsx-dev-runtime";
 import React from "react";
+import { plannedImprovementStats, plannedImprovements } from "../../data/plannedImprovements.js";
 const MAP_EDITOR_URL = "map/index.html";
 const MAP_BUTTON_LABEL = "Map Editor";
 const MAP_MODAL_WIDTH_PCT = 98;
@@ -102,6 +103,7 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
   const [showWelcome, setShowWelcome] = React.useState(() => !safeGetWelcomeFlag());
   const [showHints, setShowHints] = React.useState(false);
   const [showShowcase, setShowShowcase] = React.useState(false);
+  const [showPlannedImprovements, setShowPlannedImprovements] = React.useState(false);
   const [showcaseImages, setShowcaseImages] = React.useState(() => STATIC_SHOWCASE_IMAGES);
   const [isLoadingShowcase, setIsLoadingShowcase] = React.useState(false);
   const [showcaseError, setShowcaseError] = React.useState(null);
@@ -110,10 +112,29 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
   const mapModalContentRef = React.useRef(null);
   const previouslyFocusedElementRef = React.useRef(null);
   const showcaseButtonRef = React.useRef(null);
+  const plannedImprovementsButtonRef = React.useRef(null);
+  const plannedImprovementsCloseButtonRef = React.useRef(null);
+  const plannedImprovementsModalContentRef = React.useRef(null);
+  const plannedImprovementsPreviouslyFocusedElementRef = React.useRef(null);
   const showcaseCloseButtonRef = React.useRef(null);
   const showcaseModalContentRef = React.useRef(null);
   const showcasePreviouslyFocusedElementRef = React.useRef(null);
   const hasAttemptedDynamicShowcaseFetchRef = React.useRef(STATIC_SHOWCASE_IMAGES.length > 0);
+  const groupedPlannedImprovements = React.useMemo(() => {
+    const groups = new Map();
+    for (const item of plannedImprovements) {
+      const key = item.category || "Misc";
+      if (!groups.has(key)) {
+        groups.set(key, []);
+      }
+      groups.get(key).push(item);
+    }
+    return Array.from(groups.entries());
+  }, []);
+  const plannedImprovementsCompletionPct = React.useMemo(() => {
+    if (!plannedImprovementStats.total) return 0;
+    return Math.round((plannedImprovementStats.completed / plannedImprovementStats.total) * 100);
+  }, []);
   React.useEffect(() => {
     if (!showMapModal || !mapModalContentRef.current) return;
     const modalNode = mapModalContentRef.current;
@@ -350,13 +371,17 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
         setShowShowcase(false);
         return;
       }
+      if (showPlannedImprovements) {
+        setShowPlannedImprovements(false);
+        return;
+      }
       if (showHints) {
         setShowHints(false);
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [showMapModal, showWelcome, showShowcase, showHints]);
+  }, [showMapModal, showWelcome, showShowcase, showPlannedImprovements, showHints]);
   React.useEffect(() => {
     if (showMapModal) {
       if (mapCloseButtonRef.current) mapCloseButtonRef.current.focus();
@@ -365,6 +390,65 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
     }
     mapModalWasOpenRef.current = showMapModal;
   }, [showMapModal]);
+  React.useEffect(() => {
+    if (!showPlannedImprovements || !plannedImprovementsModalContentRef.current) {
+      return;
+    }
+    const modalNode = plannedImprovementsModalContentRef.current;
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement) {
+      plannedImprovementsPreviouslyFocusedElementRef.current = activeElement;
+    } else {
+      plannedImprovementsPreviouslyFocusedElementRef.current = null;
+    }
+    if (plannedImprovementsCloseButtonRef.current) {
+      plannedImprovementsCloseButtonRef.current.focus();
+    }
+    const focusableSelectors = "button, [href], input, select, textarea, iframe, [tabindex]:not([tabindex='-1'])";
+    const getFocusableElements = () => {
+      return Array.from(modalNode.querySelectorAll(focusableSelectors)).filter((element) => {
+        if (element.hasAttribute("disabled")) return false;
+        if (element.getAttribute("tabindex") === "-1") return false;
+        return element.getAttribute("aria-hidden") !== "true";
+      });
+    };
+    const handleKeyDown = (event) => {
+      if (event.key !== "Tab") return;
+      const focusableElements = getFocusableElements();
+      if (!focusableElements.length) {
+        event.preventDefault();
+        return;
+      }
+      if (focusableElements.length === 1) {
+        event.preventDefault();
+        focusableElements[0].focus();
+        return;
+      }
+      const [firstElement] = focusableElements;
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const currentFocus = document.activeElement;
+      if (event.shiftKey) {
+        if (currentFocus === firstElement || !modalNode.contains(currentFocus)) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+        return;
+      }
+      if (currentFocus === lastElement || !modalNode.contains(currentFocus)) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+    modalNode.addEventListener("keydown", handleKeyDown);
+    return () => {
+      modalNode.removeEventListener("keydown", handleKeyDown);
+      const previousElement = plannedImprovementsPreviouslyFocusedElementRef.current;
+      if (previousElement && typeof previousElement.focus === "function") {
+        previousElement.focus();
+      }
+      plannedImprovementsPreviouslyFocusedElementRef.current = null;
+    };
+  }, [showPlannedImprovements]);
 
   return /* @__PURE__ */ jsxDEV(
     "div",
@@ -448,6 +532,22 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
             /* @__PURE__ */ jsxDEV(
               "button",
               {
+                ref: plannedImprovementsButtonRef,
+                onClick: () => setShowPlannedImprovements(true),
+                className: "bg-gray-700 hover:bg-gray-600 text-white font-bold py-3 px-6 rounded-lg text-xl shadow-lg transform hover:scale-105 transition-all duration-200",
+                children: "Planned Improvements"
+              },
+              void 0,
+              false,
+              {
+                fileName: "<stdin>",
+                lineNumber: 55,
+                columnNumber: 21
+              }
+            ),
+            /* @__PURE__ */ jsxDEV(
+              "button",
+              {
                 onClick: onCredits,
                 className: "bg-gray-700 hover:bg-gray-600 text-white font-bold py-3 px-6 rounded-lg text-xl shadow-lg transform hover:scale-105 transition-all duration-200",
                 children: "Credits"
@@ -521,6 +621,125 @@ const MainMenu = ({ onStart, onOptions, onChangelog, onCredits, version }) => {
             fileName: "<stdin>",
             lineNumber: 75,
             columnNumber: 13
+          }
+        ),
+        showPlannedImprovements && /* @__PURE__ */ jsxDEV(
+          "div",
+          {
+            className: "fixed inset-0 z-50 flex items-center justify-center",
+            role: "dialog",
+            "aria-modal": "true",
+            "aria-labelledby": "planned-improvements-title",
+            children: [
+              /* @__PURE__ */ jsxDEV(
+                "div",
+                {
+                  className: "absolute inset-0 bg-black/70",
+                  onClick: () => setShowPlannedImprovements(false)
+                },
+                void 0,
+                false,
+                {
+                  fileName: "<stdin>",
+                  lineNumber: 112,
+                  columnNumber: 17
+                }
+              ),
+              /* @__PURE__ */ jsxDEV(
+                "div",
+                {
+                  ref: plannedImprovementsModalContentRef,
+                  className: "relative bg-gray-900 text-white border-2 border-yellow-600 rounded-xl shadow-2xl w-[95vw] max-w-[720px] max-h-[85vh] p-6 overflow-y-auto",
+                  children: [
+                    /* @__PURE__ */ jsxDEV("div", { className: "flex items-start justify-between gap-4", children: [
+                      /* @__PURE__ */ jsxDEV("div", { children: [
+                        /* @__PURE__ */ jsxDEV("h2", { id: "planned-improvements-title", className: "text-yellow-400 font-bold text-xl", children: "Planned Improvements Roadmap" }, void 0, false, {
+                          fileName: "<stdin>",
+                          lineNumber: 121,
+                          columnNumber: 25
+                        }),
+                        /* @__PURE__ */ jsxDEV("p", { className: "text-sm text-gray-300", children: `${plannedImprovementStats.completed} of ${plannedImprovementStats.total} tasks complete (${plannedImprovementsCompletionPct}%)` }, void 0, false, {
+                          fileName: "<stdin>",
+                          lineNumber: 122,
+                          columnNumber: 25
+                        }),
+                        /* @__PURE__ */ jsxDEV("div", { className: "mt-2 w-full h-3 rounded-full bg-gray-700", children: /* @__PURE__ */ jsxDEV("div", { className: "h-full rounded-full bg-yellow-500 transition-all", style: { width: `${plannedImprovementsCompletionPct}%` } }, void 0, false, {
+                          fileName: "<stdin>",
+                          lineNumber: 123,
+                          columnNumber: 27
+                        }) }, void 0, false, {
+                          fileName: "<stdin>",
+                          lineNumber: 123,
+                          columnNumber: 25
+                        })
+                      ] }, void 0, true, {
+                        fileName: "<stdin>",
+                        lineNumber: 120,
+                        columnNumber: 23
+                      }),
+                      /* @__PURE__ */ jsxDEV("button", { ref: plannedImprovementsCloseButtonRef, onClick: () => setShowPlannedImprovements(false), className: "text-red-400 hover:text-red-300 text-2xl font-bold", "aria-label": "Close planned improvements", children: "\xD7" }, void 0, false, {
+                        fileName: "<stdin>",
+                        lineNumber: 125,
+                        columnNumber: 23
+                      })
+                    ] }, void 0, true, {
+                      fileName: "<stdin>",
+                      lineNumber: 119,
+                      columnNumber: 21
+                    }),
+                    /* @__PURE__ */ jsxDEV("div", { className: "mt-4 space-y-6 text-sm", children: groupedPlannedImprovements.map(([category, items]) => /* @__PURE__ */ jsxDEV("section", { className: "space-y-2", children: [
+                      /* @__PURE__ */ jsxDEV("h3", { className: "text-yellow-300 font-semibold", children: category }, void 0, false, {
+                        fileName: "<stdin>",
+                        lineNumber: 130,
+                        columnNumber: 31
+                      }),
+                      /* @__PURE__ */ jsxDEV("ul", { className: "space-y-2", children: items.map((item) => /* @__PURE__ */ jsxDEV("li", { className: "flex items-start gap-3", children: [
+                        /* @__PURE__ */ jsxDEV("input", { type: "checkbox", checked: item.completed, disabled: true, className: "mt-0.5 h-4 w-4 rounded border-gray-500 bg-gray-800" }, void 0, false, {
+                          fileName: "<stdin>",
+                          lineNumber: 133,
+                          columnNumber: 37
+                        }),
+                        /* @__PURE__ */ jsxDEV("span", { className: "text-gray-100 leading-snug", children: item.title }, void 0, false, {
+                          fileName: "<stdin>",
+                          lineNumber: 134,
+                          columnNumber: 37
+                        })
+                      ] }, item.id, true, {
+                        fileName: "<stdin>",
+                        lineNumber: 132,
+                        columnNumber: 35
+                      })) }, void 0, false, {
+                        fileName: "<stdin>",
+                        lineNumber: 131,
+                        columnNumber: 31
+                      })
+                    ] }, category, true, {
+                      fileName: "<stdin>",
+                      lineNumber: 129,
+                      columnNumber: 29
+                    })) }, void 0, false, {
+                      fileName: "<stdin>",
+                      lineNumber: 128,
+                      columnNumber: 21
+                    })
+                  ]
+                },
+                void 0,
+                true,
+                {
+                  fileName: "<stdin>",
+                  lineNumber: 116,
+                  columnNumber: 19
+                }
+              )
+            ]
+          },
+          void 0,
+          true,
+          {
+            fileName: "<stdin>",
+            lineNumber: 110,
+            columnNumber: 15
           }
         ),
         MAP_EDITOR_ENABLED && showMapModal && /* @__PURE__ */ jsxDEV(

--- a/src/data/plannedImprovements.js
+++ b/src/data/plannedImprovements.js
@@ -1,0 +1,307 @@
+export const plannedImprovements = Object.freeze([
+  {
+    id: "core-01",
+    category: "Core Gameplay",
+    title: "Build a narrative campaign spanning six story arcs with escalating stakes and cinematic cutscenes.",
+    completed: false
+  },
+  {
+    id: "core-02",
+    category: "Core Gameplay",
+    title: "Introduce branching mission objectives that react to player choices and squad composition.",
+    completed: false
+  },
+  {
+    id: "core-03",
+    category: "Core Gameplay",
+    title: "Implement difficulty tiers for every mission with smarter AI and richer rewards on higher settings.",
+    completed: false
+  },
+  {
+    id: "core-04",
+    category: "Core Gameplay",
+    title: "Add a mission grading system (S/A/B/C) that tracks time, stealth, and damage taken.",
+    completed: false
+  },
+  {
+    id: "core-05",
+    category: "Core Gameplay",
+    title: "Create cooperative team missions that require coordinated roles and synced objectives.",
+    completed: false
+  },
+  {
+    id: "core-06",
+    category: "Core Gameplay",
+    title: "Design stealth-focused infiltration missions with visibility cones and silent takedowns.",
+    completed: false
+  },
+  {
+    id: "core-07",
+    category: "Core Gameplay",
+    title: "Build wave-based survival challenges that escalate enemy types and environmental hazards.",
+    completed: false
+  },
+  {
+    id: "core-08",
+    category: "Core Gameplay",
+    title: "Construct puzzle-driven training grounds that teach advanced mechanics through environmental riddles.",
+    completed: false
+  },
+  {
+    id: "core-09",
+    category: "Core Gameplay",
+    title: "Schedule dynamic world events that trigger invasions or defense quests on a shared timer.",
+    completed: false
+  },
+  {
+    id: "core-10",
+    category: "Core Gameplay",
+    title: "Launch multi-squad world boss encounters with telegraphed mechanics and ranked rewards.",
+    completed: false
+  },
+  {
+    id: "combat-01",
+    category: "Combat & Skills",
+    title: "Expand melee combat with combo strings, cancels, and aerial finishers for each hero.",
+    completed: false
+  },
+  {
+    id: "combat-02",
+    category: "Combat & Skills",
+    title: "Introduce a chakra management bar that governs jutsu usage and enables burst states.",
+    completed: false
+  },
+  {
+    id: "combat-03",
+    category: "Combat & Skills",
+    title: "Develop hero-specific jutsu skill trees that unlock new abilities and passive perks.",
+    completed: false
+  },
+  {
+    id: "combat-04",
+    category: "Combat & Skills",
+    title: "Add weapon loadouts with quick swapping and upgrade paths for kunai, shuriken, and blades.",
+    completed: false
+  },
+  {
+    id: "combat-05",
+    category: "Combat & Skills",
+    title: "Implement a timed guard/parry window that opens counter-attack opportunities.",
+    completed: false
+  },
+  {
+    id: "combat-06",
+    category: "Combat & Skills",
+    title: "Simulate elemental interactions where opposing chakra natures amplify or negate damage.",
+    completed: false
+  },
+  {
+    id: "combat-07",
+    category: "Combat & Skills",
+    title: "Add companion command wheels so players can assign tactics, focus targets, or healing roles.",
+    completed: false
+  },
+  {
+    id: "combat-08",
+    category: "Combat & Skills",
+    title: "Create distinct enemy archetypes (brute, healer, striker, support) with synergy behaviors.",
+    completed: false
+  },
+  {
+    id: "combat-09",
+    category: "Combat & Skills",
+    title: "Design multi-phase boss fights with breakpoints, cinematic specials, and safe-zone telegraphs.",
+    completed: false
+  },
+  {
+    id: "combat-10",
+    category: "Combat & Skills",
+    title: "Build a dojo training mode that tracks combos, DPS, and defensive drills with scoreboards.",
+    completed: false
+  },
+  {
+    id: "progression-01",
+    category: "Progression & Economy",
+    title: "Implement character leveling with stat allocation and specialization choices.",
+    completed: false
+  },
+  {
+    id: "progression-02",
+    category: "Progression & Economy",
+    title: "Create a village reputation system that unlocks discounts, missions, and cosmetic titles.",
+    completed: false
+  },
+  {
+    id: "progression-03",
+    category: "Progression & Economy",
+    title: "Add a crafting loop using gathered resources to forge gear, potions, and talismans.",
+    completed: false
+  },
+  {
+    id: "progression-04",
+    category: "Progression & Economy",
+    title: "Refresh shop inventories with rotating stock and limited-time rare items.",
+    completed: false
+  },
+  {
+    id: "progression-05",
+    category: "Progression & Economy",
+    title: "Introduce daily and weekly missions that reward currencies and progression boosts.",
+    completed: false
+  },
+  {
+    id: "progression-06",
+    category: "Progression & Economy",
+    title: "Launch an achievement system that tracks milestones and grants account-wide perks.",
+    completed: false
+  },
+  {
+    id: "progression-07",
+    category: "Progression & Economy",
+    title: "Add collectible outfits, weapon skins, and emotes earned through gameplay milestones.",
+    completed: false
+  },
+  {
+    id: "progression-08",
+    category: "Progression & Economy",
+    title: "Enable player housing where interiors can be decorated and expanded with earned props.",
+    completed: false
+  },
+  {
+    id: "progression-09",
+    category: "Progression & Economy",
+    title: "Create a summon companion system with upgradeable contracts and battlefield roles.",
+    completed: false
+  },
+  {
+    id: "progression-10",
+    category: "Progression & Economy",
+    title: "Build a mentorship feature that pairs veterans with new players for shared rewards.",
+    completed: false
+  },
+  {
+    id: "world-01",
+    category: "World & Exploration",
+    title: "Expand the overworld with new regions like the Sand Village, Mist Village, and borderlands.",
+    completed: false
+  },
+  {
+    id: "world-02",
+    category: "World & Exploration",
+    title: "Add a fast-travel scroll network unlocked by discovering landmarks.",
+    completed: false
+  },
+  {
+    id: "world-03",
+    category: "World & Exploration",
+    title: "Implement a full day-night cycle with NPC schedules and time-sensitive activities.",
+    completed: false
+  },
+  {
+    id: "world-04",
+    category: "World & Exploration",
+    title: "Simulate dynamic weather that affects visibility, traversal, and certain jutsu types.",
+    completed: false
+  },
+  {
+    id: "world-05",
+    category: "World & Exploration",
+    title: "Populate the world with ambient wildlife, gatherable plants, and interactive scenery.",
+    completed: false
+  },
+  {
+    id: "world-06",
+    category: "World & Exploration",
+    title: "Hide lore scrolls and secret collectibles that unlock codex entries and cosmetic rewards.",
+    completed: false
+  },
+  {
+    id: "world-07",
+    category: "World & Exploration",
+    title: "Enable wall-running, tree-leaping, and rooftop parkour with stamina and skill checks.",
+    completed: false
+  },
+  {
+    id: "world-08",
+    category: "World & Exploration",
+    title: "Add mini-games such as chakra races, fishing challenges, and delivery runs.",
+    completed: false
+  },
+  {
+    id: "world-09",
+    category: "World & Exploration",
+    title: "Introduce summonable mounts or gliders to speed up long-distance travel.",
+    completed: false
+  },
+  {
+    id: "world-10",
+    category: "World & Exploration",
+    title: "Design instanced hideouts and dungeons with puzzles, traps, and rare loot tables.",
+    completed: false
+  },
+  {
+    id: "social-01",
+    category: "Social & Live Systems",
+    title: "Launch a clan system with shared bases, research trees, and clan missions.",
+    completed: false
+  },
+  {
+    id: "social-02",
+    category: "Social & Live Systems",
+    title: "Add ranked and casual PvP arenas with matchmaking and seasonal ladders.",
+    completed: false
+  },
+  {
+    id: "social-03",
+    category: "Social & Live Systems",
+    title: "Provide a spectator mode with camera tools for tournaments and player-hosted events.",
+    completed: false
+  },
+  {
+    id: "social-04",
+    category: "Social & Live Systems",
+    title: "Implement safe text and emote chat channels with moderation tools and filters.",
+    completed: false
+  },
+  {
+    id: "social-05",
+    category: "Social & Live Systems",
+    title: "Create a friend list, parties, and quick-invite flow for missions and free roam.",
+    completed: false
+  },
+  {
+    id: "social-06",
+    category: "Social & Live Systems",
+    title: "Host seasonal festivals with rotating activities, narrative beats, and exclusive loot.",
+    completed: false
+  },
+  {
+    id: "social-07",
+    category: "Social & Live Systems",
+    title: "Integrate an in-game feedback, bug report, and feature voting terminal.",
+    completed: false
+  },
+  {
+    id: "social-08",
+    category: "Social & Live Systems",
+    title: "Support cross-session cloud saves so progress persists across devices.",
+    completed: false
+  },
+  {
+    id: "social-09",
+    category: "Social & Live Systems",
+    title: "Publish official modding guidelines and a lightweight SDK for custom maps or missions.",
+    completed: false
+  },
+  {
+    id: "social-10",
+    category: "Social & Live Systems",
+    title: "Deliver an interactive academy tutorial and codex that teaches advanced mechanics.",
+    completed: false
+  }
+]);
+
+export const plannedImprovementStats = Object.freeze({
+  total: plannedImprovements.length,
+  completed: plannedImprovements.filter((item) => item.completed).length
+});


### PR DESCRIPTION
## Summary
- add a 50-item planned improvements roadmap markdown checklist at the project root
- surface the roadmap inside the main menu via a read-only modal with progress indicators and focus management

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8c7ed1a483328540f0469c287b84