### PR TITLE
Update main menu changelog to v0.012

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ An in‑browser Naruto‑inspired open‑world prototype built with React and Th
 - No bundler required. The app uses ESM via CDN (`esm.sh`) and `@babel/standalone` for JSX during development.
 - A real static server is recommended so fetches and the Cache API work. Python’s `http.server` is sufficient.
 - Some assets are cross‑origin; the loader uses `no-cors` where needed and warms the HTTP cache.
-- Version label is derived from the page title token (e.g., `v0.011.000`) or the top changelog entry.
+- Version label is derived from the page title token (e.g., `v0.012`) or the top changelog entry.
 - Recent changes are visible in the in‑game Changelog panel.
 
 ### Changelog & Versioning (for contributors)

--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,5 @@
 Recent
+- Changelog: Published v0.012 entry with synced multiplayer updates and trimmed trailing .000 from version labels.
 - Main Menu: Added a read-only Planned Improvements modal sourced from a 50-item roadmap checklist.
 - Multiplayer: Wired the main world into Websim presence so other players spawn with synced movement, rotation, and character identity; index.html now loads the WebsimSocket client script.
 - Main Menu: Added a Showcase gallery modal that surfaces src/assets/images/showcase/ images (auto-detected, no manifest needed) and opens them full size.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Naruto RPG v0.011.000 [Alpha]</title>
+    <title>Naruto RPG v0.012 [Alpha]</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="styles/style.css">
     <script async src="https://ga.jspm.io/npm:es-module-shims@1.7.0/dist/es-module-shims.js"></script>

--- a/src/components/UI/ChangelogPanel.jsx
+++ b/src/components/UI/ChangelogPanel.jsx
@@ -24,7 +24,20 @@ const LATEST_VERSION = deriveLatestVersion();
 
 // Keep newest entry first so OpenWorldGame can read the latest version
 export const changelogData = [
-  // Today (new): 2025-09-27
+  {
+    version: "0.012",
+    date: "2025-10-05",
+    changes: [
+      "Main Menu: Added shinobi picker alongside new Showcase gallery and Planned Improvements modal.",
+      "Multiplayer: Synced party spawns/movement through Websim presence so friends load into the same world.",
+      "NPCs: Introduced Orochimaru and Neji with expanded wander/dialog flows and local mugshots.",
+      "Movement/Collision: Tightened strafe displacement, scaled actors, and matched FPV eye height to new proportions.",
+      "Loading: Spawn squadmates together, keep pointer lock during dialog, and streamline the progress overlay.",
+      "Audio: Added the 'Akatsuki Theme' to the background music rotation.",
+      "Docs: Expanded README guidance covering setup, features, and contributor workflow."
+    ]
+  },
+  // Previous (kept intact): 2025-09-27
   {
     version: "0.011.000",
     date: "2025-09-27",


### PR DESCRIPTION
## Summary
- add a 0.012 release entry to the main menu changelog with the latest feature highlights
- bump the displayed version label to v0.012 and update documentation references
- log the changelog refresh in changes.md for the running review history

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd90420080833283a7a06233f85788