### PR TITLE
Release pointer lock during NPC dialog

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,5 @@
 Recent
+- NPC Dialog: Opening conversations now exits pointer lock and suspends gameplay input so FPV players stay grounded mid-talk.
 - Loading UI: decouple progress updates into a shared store, smooth the bar, and tie minimum progress to completed stages for accurate feedback.
 - Assets: Precache local UI, map, and mugshot images during the loading phase to avoid refetches in later panels.
 - Loading: Track scene initialization as its own step and smooth progress updates through squad deployment.

--- a/src/OpenWorldGame.jsx
+++ b/src/OpenWorldGame.jsx
@@ -283,8 +283,17 @@ const OpenWorldGame = () => {
     window.addEventListener("open-kitbash-building", openKit);
     const openNpc = (e) => {
       // Do not pause the game or music for NPC dialog
-      // Keep FPV active: do NOT release pointer lock here so interacting in FPV doesn't dump to third-person.
-      setNpcDialogData(e?.detail || null);
+      const detail = e?.detail || null;
+      try {
+        window.__npcDialogActive = true;
+      } catch (_) {}
+      try {
+        window.__clearPlayerControlState?.();
+      } catch (_) {}
+      try {
+        if (document.pointerLockElement) document.exitPointerLock();
+      } catch (_) {}
+      setNpcDialogData(detail);
       setShowNpcDialog(true);
     };
     window.addEventListener("open-npc-dialog", openNpc);
@@ -610,6 +619,8 @@ const OpenWorldGame = () => {
       // Close NPC dialog without touching global pause/music
       setShowNpcDialog(false);
       setNpcDialogData(null);
+      try { window.__npcDialogActive = false; } catch (_) {}
+      try { window.__clearPlayerControlState?.(); } catch (_) {}
       // Release interaction lock if set
       try { if (window.__npcInteracting) { window.__npcInteracting.userData.interacting = false; delete window.__npcInteracting; } } catch (_) {}
     }, npcName: (npcDialogData == null ? void 0 : npcDialogData.npc) || "NPC", npcImage: (npcDialogData == null ? void 0 : npcDialogData.npcImage) || "", playerName: (npcDialogData == null ? void 0 : npcDialogData.player) || "You", playerImage: (npcDialogData == null ? void 0 : npcDialogData.playerImage) || "", lines: (npcDialogData == null ? void 0 : npcDialogData.lines) || [] }, void 0, false) }, void 0, false),

--- a/src/hooks/usePlayerControls.js
+++ b/src/hooks/usePlayerControls.js
@@ -5,9 +5,18 @@ export const usePlayerControls = ({ setShowCharacter, setShowInventory, setShowW
     const keysRef = useRef({});
 
     useEffect(() => {
+        const clearControlState = () => {
+            keysRef.current = {};
+        };
+        window.__clearPlayerControlState = clearControlState;
+
         const handleKeyDown = (event) => {
             // Prevent panel toggling if an input field is focused
             if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA' || event.target.isContentEditable) {
+                return;
+            }
+
+            if (window.__npcDialogActive) {
                 return;
             }
 
@@ -163,11 +172,18 @@ export const usePlayerControls = ({ setShowCharacter, setShowInventory, setShowW
         };
 
         const handleKeyUp = (event) => {
+            if (window.__npcDialogActive) {
+                keysRef.current[event.code] = false;
+                return;
+            }
             keysRef.current[event.code] = false;
         };
 
         // Mouse buttons (bind left-click for attack)
         const handleMouseDown = (event) => {
+            if (window.__npcDialogActive) {
+                return;
+            }
             if (window.__gamePaused) {
                 return;
             }
@@ -194,6 +210,9 @@ export const usePlayerControls = ({ setShowCharacter, setShowInventory, setShowW
             window.removeEventListener('keyup', handleKeyUp);
             window.removeEventListener('mousedown', handleMouseDown);
             window.removeEventListener('mouseup', handleMouseUp);
+            if (window.__clearPlayerControlState === clearControlState) {
+                delete window.__clearPlayerControlState;
+            }
         };
     }, [setShowCharacter, setShowInventory, setShowWorldMap, setShowSettings, setShowMobileControls, setShowAnimations, setShowJutsuModal, setShowKakashi, gameState, setSettings, setShowPause]);
 


### PR DESCRIPTION
## Summary
- release pointer lock and clear active controls when opening NPC dialog so first-person players can use the cursor
- mark NPC dialogs as active to suppress gameplay input until the conversation closes
- log the UX adjustment in changes.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec8fd33f0833281a180a659518407