### PR TITLE
Keep FPV active during NPC interactions

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,5 @@
 Recent
+- FPV/NPC Dialog: Keep first-person active during conversations by suspending controls and restoring pointer lock on close.
 - NPC Dialog: Opening conversations now exits pointer lock and suspends gameplay input so FPV players stay grounded mid-talk.
 - Loading UI: decouple progress updates into a shared store, smooth the bar, and tie minimum progress to completed stages for accurate feedback.
 - Assets: Precache local UI, map, and mugshot images during the loading phase to avoid refetches in later panels.

--- a/src/OpenWorldGame.jsx
+++ b/src/OpenWorldGame.jsx
@@ -284,14 +284,21 @@ const OpenWorldGame = () => {
     const openNpc = (e) => {
       // Do not pause the game or music for NPC dialog
       const detail = e?.detail || null;
+      const pointerWasLocked = !!document.pointerLockElement;
       try {
         window.__npcDialogActive = true;
       } catch (_) {}
       try {
         window.__clearPlayerControlState?.();
       } catch (_) {}
+      if (pointerWasLocked) {
+        try {
+          window.__suspendPointerLockSync = true;
+          window.__resumePointerLockAfterDialog = true;
+        } catch (_) {}
+      }
       try {
-        if (document.pointerLockElement) document.exitPointerLock();
+        if (pointerWasLocked) document.exitPointerLock();
       } catch (_) {}
       setNpcDialogData(detail);
       setShowNpcDialog(true);
@@ -619,10 +626,21 @@ const OpenWorldGame = () => {
       // Close NPC dialog without touching global pause/music
       setShowNpcDialog(false);
       setNpcDialogData(null);
+      const shouldRestorePointerLock = !!window.__resumePointerLockAfterDialog;
       try { window.__npcDialogActive = false; } catch (_) {}
       try { window.__clearPlayerControlState?.(); } catch (_) {}
       // Release interaction lock if set
       try { if (window.__npcInteracting) { window.__npcInteracting.userData.interacting = false; delete window.__npcInteracting; } } catch (_) {}
+      if (shouldRestorePointerLock) {
+        try {
+          const canvas = document.querySelector('canvas');
+          if (canvas && canvas.requestPointerLock && document.pointerLockElement !== canvas) {
+            canvas.requestPointerLock();
+          }
+        } catch (_) {}
+      }
+      try { delete window.__resumePointerLockAfterDialog; } catch (_) {}
+      try { delete window.__suspendPointerLockSync; } catch (_) {}
     }, npcName: (npcDialogData == null ? void 0 : npcDialogData.npc) || "NPC", npcImage: (npcDialogData == null ? void 0 : npcDialogData.npcImage) || "", playerName: (npcDialogData == null ? void 0 : npcDialogData.player) || "You", playerImage: (npcDialogData == null ? void 0 : npcDialogData.playerImage) || "", lines: (npcDialogData == null ? void 0 : npcDialogData.lines) || [] }, void 0, false) }, void 0, false),
     eventOverlay && /* @__PURE__ */ jsxDEV(WorldEventOverlay, { overlay: eventOverlay, onConfirm: acknowledgeEvent, onDismiss: dismissEventOverlay }, void 0, false)
   ] }, void 0, true, {

--- a/src/scene/animationLoop.js
+++ b/src/scene/animationLoop.js
@@ -93,8 +93,9 @@ export function startAnimationLoop({
     const onPointerLockChange = () => {
         const el = rendererRef.current?.domElement;
         const isLocked = (document.pointerLockElement === el);
-        // Sync FPV state purely from actual pointer-lock status
-        firstPersonRef.current = !!isLocked;
+        const suppressUnlockEffects = !!window.__suspendPointerLockSync && !isLocked;
+        // Sync FPV state, but keep FPV active if we're intentionally suspending pointer lock
+        firstPersonRef.current = suppressUnlockEffects ? true : !!isLocked;
 
         // Keep orientation consistent when entering/leaving FPV
         try {
@@ -102,7 +103,10 @@ export function startAnimationLoop({
             if (isLocked && model && cameraOrbitRef) {
                 // Entering FPV: mirror model yaw into camera orbit
                 cameraOrbitRef.current = model.rotation.y || 0;
-            } else if (!isLocked && model && cameraOrbitRef) {
+                if (window.__suspendPointerLockSync) {
+                    try { delete window.__suspendPointerLockSync; } catch (_) {}
+                }
+            } else if (!isLocked && model && cameraOrbitRef && !suppressUnlockEffects) {
                 // Leaving FPV: keep player facing where they looked in FPV,
                 // and place third-person camera behind the player (add PI)
                 const yaw = cameraOrbitRef.current || 0;
@@ -112,8 +116,10 @@ export function startAnimationLoop({
         } catch (_) {}
     };
     const onPointerLockError = () => {
-        // If lock fails, ensure FPV is off
+        // If lock fails, ensure FPV is off and clear any pending suspension flags
         firstPersonRef.current = false;
+        try { delete window.__suspendPointerLockSync; } catch (_) {}
+        try { delete window.__resumePointerLockAfterDialog; } catch (_) {}
     };
     document.addEventListener('pointerlockchange', onPointerLockChange);
     document.addEventListener('pointerlockerror', onPointerLockError);


### PR DESCRIPTION
## Summary
- preserve first-person mode when NPC dialog opens by suspending pointer-lock reactions and restoring the lock after closing
- ensure the animation loop ignores intentional pointer lock releases and cleans up any temporary flags
- document the behavior change in the running changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68decad74d6c8332a1c671bde5296bdb