### PR TITLE
Add unit tests for experience and quest rewards

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -35,3 +35,4 @@ Recent
 - UI: Rebuilt the character select modal without JSX so the browser can load it without a bundle step.
 - Player Loader: Pointed manifest fallbacks at the local temp bundles so non-Kakashi picks use available GLBs instead of 404s.
 - World: Skip spawning the chosen hero as an NPC and expose squad roster info so loading progress stays accurate when the roster changes.
+- Tests: Added coverage for experience leveling, quest rewards, and edge cases.

--- a/tests/game/experience.test.js
+++ b/tests/game/experience.test.js
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { xpForLevel, ensureExperienceConsistency, addExperience } from '../../src/game/experience.js';
+
+test('xpForLevel enforces minimums and scales linearly', () => {
+  assert.equal(xpForLevel(1), 250);
+  assert.equal(xpForLevel(12), 3000);
+  assert.equal(xpForLevel(0), 250, 'levels below 1 clamp to level 1 baseline');
+  assert.equal(xpForLevel(-5), 250, 'negative levels use baseline requirement');
+  assert.equal(xpForLevel(100), 25000, 'high level still follows linear growth');
+});
+
+test('ensureExperienceConsistency clamps experience and maxExperience', () => {
+  const input = {
+    level: 5,
+    experience: 9999,
+    maxExperience: 10,
+  };
+
+  const result = ensureExperienceConsistency(input);
+
+  assert.notEqual(result, input, 'should return a cloned stats object');
+  assert.equal(result.maxExperience, xpForLevel(5));
+  assert.equal(result.experience, xpForLevel(5) - 1, 'experience clamps to just below the level cap');
+
+  const negative = ensureExperienceConsistency({ level: 3, experience: -50 });
+  assert.equal(negative.experience, 0, 'negative experience resets to zero');
+  assert.equal(negative.maxExperience, xpForLevel(3));
+});
+
+test('addExperience handles multi-level ups, stat growth, and refills vitals', () => {
+  const original = {
+    level: 1,
+    experience: 200,
+    maxExperience: xpForLevel(1),
+    maxHealth: 100,
+    health: 40,
+    maxChakra: 80,
+    chakra: 10,
+    maxStamina: 60,
+    stamina: 5,
+    attackRating: 15,
+    defense: 12,
+    minDamage: 3,
+    maxDamage: 7,
+    statPoints: 0,
+    skillPoints: 0,
+  };
+
+  const { stats, leveledUp, levelsGained } = addExperience(original, 600);
+
+  assert.equal(levelsGained, 2);
+  assert.equal(leveledUp, true);
+  assert.equal(stats.level, 3);
+  assert.equal(stats.experience, 50);
+  assert.equal(stats.maxExperience, xpForLevel(3));
+  assert.equal(stats.maxHealth, 120);
+  assert.equal(stats.health, stats.maxHealth, 'health refills to new maximum');
+  assert.equal(stats.maxChakra, 100);
+  assert.equal(stats.chakra, stats.maxChakra, 'chakra refills to new maximum');
+  assert.equal(stats.maxStamina, 70);
+  assert.equal(stats.stamina, stats.maxStamina, 'stamina refills to new maximum');
+  assert.equal(stats.attackRating, 19);
+  assert.equal(stats.defense, 16);
+  assert.equal(stats.minDamage, 5);
+  assert.equal(stats.maxDamage, 9);
+  assert.equal(stats.statPoints, 10);
+  assert.equal(stats.skillPoints, 2);
+
+  assert.deepEqual(original, {
+    level: 1,
+    experience: 200,
+    maxExperience: xpForLevel(1),
+    maxHealth: 100,
+    health: 40,
+    maxChakra: 80,
+    chakra: 10,
+    maxStamina: 60,
+    stamina: 5,
+    attackRating: 15,
+    defense: 12,
+    minDamage: 3,
+    maxDamage: 7,
+    statPoints: 0,
+    skillPoints: 0,
+  }, 'input stats remain unchanged');
+});
+
+test('addExperience clamps invalid experience gain requests', () => {
+  const base = {
+    level: 2,
+    experience: -10,
+    maxExperience: 10,
+  };
+
+  const { stats, leveledUp, levelsGained } = addExperience(base, -50);
+
+  assert.equal(leveledUp, false);
+  assert.equal(levelsGained, 0);
+  assert.equal(stats.experience, 0);
+  assert.equal(stats.level, 2);
+  assert.equal(stats.maxExperience, xpForLevel(2));
+});

--- a/tests/game/quests.test.js
+++ b/tests/game/quests.test.js
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyQuestRewards } from '../../src/game/quests.js';
+
+function createState(initialStats = {}, initialInventory = {}, addExperienceImpl = () => {}) {
+  let stats = structuredClone(initialStats);
+  let inventory = structuredClone(initialInventory);
+  const statCalls = [];
+  const inventoryCalls = [];
+  const addExpCalls = [];
+
+  const setPlayerStats = updater => {
+    statCalls.push(updater);
+    stats = updater(stats);
+  };
+
+  const setInventory = updater => {
+    inventoryCalls.push(updater);
+    inventory = updater(inventory);
+  };
+
+  const addExperience = amount => {
+    addExpCalls.push(amount);
+    addExperienceImpl(amount);
+  };
+
+  return {
+    setPlayerStats,
+    setInventory,
+    addExperience,
+    getStats: () => stats,
+    getInventory: () => inventory,
+    statCalls,
+    inventoryCalls,
+    addExpCalls,
+  };
+}
+
+test('applyQuestRewards applies XP and gold rewards via setters', () => {
+  const state = createState({ gold: 10 }, { storage: [] }, () => {});
+
+  applyQuestRewards(
+    [
+      { type: 'xp', amount: 150 },
+      { type: 'gold', amount: 50 },
+    ],
+    state,
+  );
+
+  assert.deepEqual(state.addExpCalls, [150]);
+  assert.equal(state.getStats().gold, 60);
+  assert.equal(state.statCalls.length, 1, 'gold updates use setter callback');
+});
+
+test('applyQuestRewards inserts items into the first available storage slot', () => {
+  const state = createState({}, { storage: [null, { name: 'Scroll' }] }, () => {});
+  const rewardItem = { name: 'Chakra Potion', icon: '🧪' };
+
+  applyQuestRewards(
+    [
+      { type: 'item', item: rewardItem },
+    ],
+    state,
+  );
+
+  const inventory = state.getInventory();
+  assert.equal(inventory.storage[0]?.name, 'Chakra Potion');
+  assert.equal(inventory.storage[1]?.name, 'Scroll');
+  assert.equal(state.inventoryCalls.length, 1, 'inventory setter invoked once');
+});
+
+test('applyQuestRewards upgrades equipped items when gear exists', () => {
+  const initialInventory = {
+    equipment: {
+      weapon: {
+        name: 'Kunai',
+        rarity: 'common',
+        stats: { attack: 10 },
+        durability: { current: 80, max: 100 },
+      },
+    },
+    storage: [],
+  };
+
+  const state = createState({}, initialInventory, () => {});
+
+  applyQuestRewards(
+    [
+      {
+        type: 'upgrade',
+        slot: 'weapon',
+        modifiers: {
+          rarity: 'rare',
+          nameSuffix: '+1',
+          stats: { attack: 5, agility: 2 },
+          durability: { current: 10, max: 20 },
+        },
+      },
+    ],
+    state,
+  );
+
+  const upgraded = state.getInventory().equipment.weapon;
+  assert.equal(upgraded.rarity, 'rare');
+  assert.equal(upgraded.name, 'Kunai +1');
+  assert.equal(upgraded.stats.attack, 15);
+  assert.equal(upgraded.stats.agility, 2);
+  assert.equal(upgraded.durability.max, 120);
+  assert.equal(upgraded.durability.current, 90);
+  assert.equal(state.getInventory().storage.length, 0);
+});
+
+test('applyQuestRewards creates storage item when upgrading empty slot', () => {
+  const state = createState(
+    {},
+    {
+      equipment: { weapon: null },
+      storage: [undefined, { name: 'Shuriken' }],
+    },
+    () => {},
+  );
+
+  applyQuestRewards(
+    [
+      { type: 'upgrade', slot: 'weapon', modifiers: { rarity: 'epic', stats: { attack: 7 } } },
+    ],
+    state,
+  );
+
+  const storage = state.getInventory().storage;
+  assert.equal(storage[0].slot, 'weapon');
+  assert.equal(storage[0].rarity, 'epic');
+  assert.equal(storage[0].stats.attack, 7);
+  assert.equal(storage[1].name, 'Shuriken');
+});
+
+test('applyQuestRewards safely ignores unknown reward types and empty lists', () => {
+  const state = createState({ gold: 5 }, { storage: [] }, () => {});
+  let warnMessages = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => {
+    warnMessages.push(args.join(' '));
+  };
+
+  try {
+    applyQuestRewards([], state);
+    applyQuestRewards([{ type: 'mystery', amount: 10 }], state);
+    applyQuestRewards(null, state);
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(state.statCalls.length, 0, 'no setters triggered for ignored rewards');
+  assert.equal(state.inventoryCalls.length, 0, 'inventory untouched for ignored rewards');
+  assert.equal(state.addExpCalls.length, 0, 'experience untouched for ignored rewards');
+  assert.ok(warnMessages.some(msg => msg.includes('Unknown reward type')));
+});


### PR DESCRIPTION
## Summary
- add node:test coverage for experience leveling helpers including multi-level ups and clamping
- add quest reward tests for XP, gold, storage insertions, upgrades, and ignored reward regressions
- record the new coverage in the running changelog

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68ded2b18d5c8332928c9d1048bbb8b6