### PR TITLE
Add coverage for music manager and pause state safeguards

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -45,3 +45,4 @@ Recent
 - Tests: Added character catalog coverage to ensure identity, stats, and inventory builders clone data and honor overrides.
 
 - Tests: Added district layout utility coverage for normalization, cloning, caching, and reload paths.
+- Tests: Hardened music playback and pause safety with mocked audio, cache fallbacks, and pointer lock coverage.

--- a/tests/utils/musicManager.test.js
+++ b/tests/utils/musicManager.test.js
@@ -1,0 +1,201 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import playlist from '../../src/assets/songs/playlist.js';
+
+function createAudioMocks() {
+  const instances = [];
+  const AudioMock = vi.fn(() => {
+    const listeners = new Map();
+    const audio = {
+      readyState: 3,
+      src: '',
+      preload: '',
+      crossOrigin: '',
+      currentTime: 0,
+      duration: 120,
+      volume: 0,
+      load: vi.fn(),
+      play: vi.fn(() => Promise.resolve()),
+      pause: vi.fn(),
+      addEventListener: vi.fn((event, handler) => {
+        listeners.set(event, handler);
+      }),
+      removeEventListener: vi.fn((event, handler) => {
+        const stored = listeners.get(event);
+        if (stored && (!handler || stored === handler)) {
+          listeners.delete(event);
+        }
+      }),
+      trigger(event) {
+        const handler = listeners.get(event);
+        if (handler) handler();
+      }
+    };
+    instances.push(audio);
+    return audio;
+  });
+  return { AudioMock, instances };
+}
+
+describe('musicManager', () => {
+  let AudioMock;
+  let audioInstances;
+  let cacheAddMock;
+  let openMock;
+  let originalCaches;
+
+  beforeEach(() => {
+    vi.resetModules();
+    cacheAddMock = vi.fn(() => Promise.resolve());
+    ({ AudioMock, instances: audioInstances } = createAudioMocks());
+    openMock = vi.fn(async () => ({ add: cacheAddMock }));
+    vi.stubGlobal('Audio', AudioMock);
+    originalCaches = globalThis.caches;
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      writable: true,
+      value: { open: openMock }
+    });
+    localStorage.removeItem('musicVolume');
+    // eslint-disable-next-line no-underscore-dangle
+    delete window.__music;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    localStorage.clear();
+    // eslint-disable-next-line no-underscore-dangle
+    delete window.__music;
+    if (originalCaches === undefined) {
+      delete globalThis.caches;
+    } else {
+      Object.defineProperty(globalThis, 'caches', {
+        configurable: true,
+        writable: true,
+        value: originalCaches
+      });
+    }
+  });
+
+  it('preloads playlist entries into mocked audio instances', async () => {
+    const { preloadMusic, musicState } = await import('../../src/utils/musicManager.js');
+    const progressSpy = vi.fn();
+
+    await preloadMusic(progressSpy);
+
+    expect(AudioMock).toHaveBeenCalledTimes(playlist.length);
+    expect(audioInstances.map((a) => a.src)).toEqual(playlist.map((t) => t.src));
+    expect(audioInstances.every((a) => a.volume === 0.05)).toBe(true);
+    expect(progressSpy).toHaveBeenCalled();
+    expect(musicState()).toMatchObject({ ready: true, isPlaying: false, index: 0 });
+  });
+
+  it('plays, pauses, toggles music, and notifies subscribers', async () => {
+    const {
+      preloadMusic,
+      musicToggle,
+      musicPause,
+      musicState,
+      musicSubscribe
+    } = await import('../../src/utils/musicManager.js');
+
+    const listener = vi.fn();
+    const unsubscribe = musicSubscribe(listener);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ ready: false, isPlaying: false }));
+    listener.mockClear();
+
+    await preloadMusic();
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ ready: true }));
+    listener.mockClear();
+
+    await musicToggle();
+    await Promise.resolve();
+    expect(audioInstances[0].play).toHaveBeenCalledTimes(1);
+    expect(musicState().isPlaying).toBe(true);
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ isPlaying: true }));
+
+    musicPause();
+    expect(audioInstances[0].pause).toHaveBeenCalledTimes(1);
+    expect(musicState().isPlaying).toBe(false);
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ isPlaying: false }));
+
+    await musicToggle();
+    await Promise.resolve();
+    expect(audioInstances[0].play).toHaveBeenCalledTimes(2);
+    expect(musicState().isPlaying).toBe(true);
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ isPlaying: true }));
+
+    unsubscribe();
+  });
+
+  it('clamps volume values and updates listeners and audio instances', async () => {
+    const {
+      preloadMusic,
+      musicSetVolume,
+      musicState,
+      musicSubscribe
+    } = await import('../../src/utils/musicManager.js');
+
+    await preloadMusic();
+
+    const listener = vi.fn();
+    const unsubscribe = musicSubscribe(listener);
+    listener.mockClear();
+
+    musicSetVolume(2);
+    expect(musicState().volume).toBe(1);
+    expect(audioInstances.every((a) => a.volume === 1)).toBe(true);
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ volume: 1 }));
+
+    listener.mockClear();
+    musicSetVolume(-0.4);
+    expect(musicState().volume).toBe(0);
+    expect(audioInstances.every((a) => a.volume === 0)).toBe(true);
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ volume: 0 }));
+
+    listener.mockClear();
+    musicSetVolume('invalid');
+    expect(listener).not.toHaveBeenCalled();
+    expect(musicState().volume).toBe(0);
+
+    unsubscribe();
+  });
+
+  it('uses cache storage gracefully across hits and misses', async () => {
+    const originalRequest = globalThis.Request;
+    class FakeRequest {
+      constructor(input, init = {}) {
+        this.url = typeof input === 'string' ? input : input?.url ?? '';
+        this.init = init;
+      }
+    }
+    Object.defineProperty(globalThis, 'Request', {
+      configurable: true,
+      writable: true,
+      value: FakeRequest
+    });
+
+    cacheAddMock.mockImplementation((request) => {
+      const url = request?.url ?? String(request);
+      return url.includes('Town1') ? Promise.reject(new Error('cache miss')) : Promise.resolve();
+    });
+
+    try {
+      const { preloadMusic } = await import('../../src/utils/musicManager.js');
+
+      await expect(preloadMusic()).resolves.toBeUndefined();
+      expect(openMock).toHaveBeenCalledWith('music-assets-v1');
+      expect(cacheAddMock).toHaveBeenCalled();
+    } finally {
+      if (originalRequest === undefined) {
+        delete globalThis.Request;
+      } else {
+        Object.defineProperty(globalThis, 'Request', {
+          configurable: true,
+          writable: true,
+          value: originalRequest
+        });
+      }
+    }
+  });
+});

--- a/tests/utils/pauseState.test.js
+++ b/tests/utils/pauseState.test.js
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { exitPointerLockSafely, openPauseGate, closePauseGate } from '../../src/utils/pauseState.js';
+
+describe('pauseState utilities', () => {
+  let exitPointerLockMock;
+  let pointerLockElementDescriptor;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    exitPointerLockMock = vi.fn();
+    Object.defineProperty(document, 'exitPointerLock', {
+      configurable: true,
+      writable: true,
+      value: exitPointerLockMock
+    });
+    pointerLockElementDescriptor = Object.getOwnPropertyDescriptor(document, 'pointerLockElement');
+    Object.defineProperty(document, 'pointerLockElement', {
+      configurable: true,
+      writable: true,
+      value: null
+    });
+    // eslint-disable-next-line no-underscore-dangle
+    delete window.__gamePaused;
+    // eslint-disable-next-line no-underscore-dangle
+    delete window.__pauseMenuActive;
+    // eslint-disable-next-line no-underscore-dangle
+    delete window.__pauseMenuWasPausedBefore;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line no-underscore-dangle
+    delete window.__gamePaused;
+    // eslint-disable-next-line no-underscore-dangle
+    delete window.__pauseMenuActive;
+    // eslint-disable-next-line no-underscore-dangle
+    delete window.__pauseMenuWasPausedBefore;
+    if (pointerLockElementDescriptor) {
+      Object.defineProperty(document, 'pointerLockElement', pointerLockElementDescriptor);
+    } else {
+      delete document.pointerLockElement;
+    }
+    delete document.exitPointerLock;
+  });
+
+  it('exits pointer lock only when an element is locked and swallows exit errors', () => {
+    document.pointerLockElement = {};
+    exitPointerLockSafely();
+    expect(exitPointerLockMock).toHaveBeenCalledTimes(1);
+
+    exitPointerLockMock.mockImplementationOnce(() => { throw new Error('fail'); });
+    document.pointerLockElement = {};
+    expect(() => exitPointerLockSafely()).not.toThrow();
+    expect(exitPointerLockMock).toHaveBeenCalledTimes(2);
+
+    document.pointerLockElement = null;
+    exitPointerLockSafely();
+    expect(exitPointerLockMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('opens the pause gate, tracks previous pause state, and unlocks pointer when requested', () => {
+    document.pointerLockElement = { nodeName: 'CANVAS' };
+    // eslint-disable-next-line no-underscore-dangle
+    window.__gamePaused = false;
+
+    const wasPaused = openPauseGate();
+    expect(wasPaused).toBe(false);
+    expect(exitPointerLockMock).toHaveBeenCalledTimes(1);
+    expect(window.__pauseMenuActive).toBe(true);
+    expect(window.__pauseMenuWasPausedBefore).toBe(false);
+    expect(window.__gamePaused).toBe(true);
+
+    exitPointerLockMock.mockClear();
+    document.pointerLockElement = { nodeName: 'CANVAS' };
+    // eslint-disable-next-line no-underscore-dangle
+    window.__gamePaused = true;
+
+    const wasPausedAlready = openPauseGate();
+    expect(wasPausedAlready).toBe(true);
+    expect(window.__pauseMenuWasPausedBefore).toBe(true);
+    expect(exitPointerLockMock).toHaveBeenCalledTimes(1);
+
+    exitPointerLockMock.mockClear();
+    document.pointerLockElement = { nodeName: 'CANVAS' };
+    openPauseGate({ forcePointerUnlock: false });
+    expect(exitPointerLockMock).not.toHaveBeenCalled();
+  });
+
+  it('closes the pause gate and restores the previous pause state', () => {
+    // Start unpaused -> open -> close should leave game unpaused
+    const wasPaused = openPauseGate();
+    expect(wasPaused).toBe(false);
+    closePauseGate();
+    expect(window.__gamePaused).toBe(false);
+    expect(window.__pauseMenuActive).toBeUndefined();
+    expect(window.__pauseMenuWasPausedBefore).toBeUndefined();
+
+    // Start paused -> open -> close should keep pause flag
+    // eslint-disable-next-line no-underscore-dangle
+    window.__gamePaused = true;
+    openPauseGate();
+    closePauseGate();
+    expect(window.__gamePaused).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest coverage for the music manager including mocked audio instances, cache fallbacks, and listener notifications
- cover pause gate utilities to ensure pointer lock exit and pause restoration paths behave as expected
- document the new safeguards in the running changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deddf91c488332b5e9c0e4de3dd836