### PR TITLE
Add devtools time presets

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -47,3 +47,5 @@ Recent
 - Tests: Added district layout utility coverage for normalization, cloning, caching, and reload paths.
 - Tests: Hardened music playback and pause safety with mocked audio, cache fallbacks, and pointer lock coverage.
 - World: Kitbashed building windows now glow at night with randomized late-night lights-out behavior tied to the day/night cycle.
+
+- Devtools: Added console helpers to jump the world clock to dawn, midday, dusk, or night presets.

--- a/src/OpenWorldGame.jsx
+++ b/src/OpenWorldGame.jsx
@@ -32,6 +32,7 @@ import HokageOfficeModal from "./components/UI/HokageOfficeModal.jsx";
 import KitbashBuildingModal from "./components/UI/KitbashBuildingModal.jsx";
 import JutsuModal from "./components/UI/JutsuModal.jsx";
 import { preloadMusic, musicPlay, musicPause, musicState } from "./utils/musicManager.js";
+import { registerTimeDevtools } from "./utils/devtools.js";
 import { useGameTime } from "./hooks/useGameTime.js";
 import CharacterSelectModal from "./components/UI/CharacterSelectModal.jsx";
 import { PLAYER_CHARACTERS, getCharacterByKey, getDefaultCharacter, buildStatsForCharacter, buildInventoryForCharacter } from "./game/player/characterCatalog.js";
@@ -130,7 +131,15 @@ const OpenWorldGame = () => {
   const [showJutsuModal, setShowJutsuModal] = useState(false);
   const [quests, setQuests] = useState(() => createInitialQuests());
   // In-game time must be computed before passing to world events
-  const { timeOfDayHours, formattedTime: gameClock } = useGameTime({ isRunning: gameState === "Playing", initialHour: 8, resetKey: timeResetKey });
+  const { timeOfDayHours, formattedTime: gameClock, setTimeOfDay } = useGameTime({ isRunning: gameState === "Playing", initialHour: 8, resetKey: timeResetKey });
+  const timeOfDayRef = useRef(timeOfDayHours);
+  useEffect(() => {
+    timeOfDayRef.current = timeOfDayHours;
+  }, [timeOfDayHours]);
+  useEffect(() => registerTimeDevtools({
+    getTimeOfDayHours: () => timeOfDayRef.current,
+    setTimeOfDayHours: setTimeOfDay
+  }), [setTimeOfDay]);
   const { worldState, eventOverlay, acknowledgeEvent, dismissEventOverlay, activeEvent, upcomingEvent, nextEventCountdownMs } = useWorldEvents({ gameState, timeOfDayHours });
   const uiState = {
     setShowCharacter,

--- a/src/hooks/useGameTime.js
+++ b/src/hooks/useGameTime.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { nowHighResMs, formatGameClock, isGamePaused } from '../utils/time.js';
 
 const SECONDS_PER_HOUR = 60 * 60;
@@ -65,6 +65,24 @@ export function useGameTime({ isRunning, initialHour = 8, tickIntervalMs = 250, 
     };
   }, [isRunning, tickIntervalMs, resetKey]);
 
+  const setTimeOfDay = useCallback((hour) => {
+    let nextHour = hour;
+    if (typeof nextHour === 'string' && nextHour.trim() !== '') {
+      const parsed = Number(nextHour);
+      if (Number.isFinite(parsed)) {
+        nextHour = parsed;
+      }
+    }
+    if (!Number.isFinite(nextHour)) {
+      nextHour = timeRef.current / SECONDS_PER_HOUR;
+    }
+    const normalized = clampHour(nextHour);
+    const seconds = normalized * SECONDS_PER_HOUR;
+    timeRef.current = seconds;
+    setDisplaySeconds(seconds);
+    return normalized;
+  }, []);
+
   const timeOfDayHours = displaySeconds / SECONDS_PER_HOUR;
   const normalizedDayProgress = displaySeconds / SECONDS_PER_DAY;
 
@@ -72,6 +90,7 @@ export function useGameTime({ isRunning, initialHour = 8, tickIntervalMs = 250, 
     timeOfDayHours,
     normalizedDayProgress,
     totalSeconds: displaySeconds,
-    formattedTime: formatGameClock(displaySeconds)
+    formattedTime: formatGameClock(displaySeconds),
+    setTimeOfDay
   };
 }

--- a/src/utils/devtools.js
+++ b/src/utils/devtools.js
@@ -1,0 +1,110 @@
+import { formatGameClock, SECONDS_PER_HOUR } from './time.js';
+
+const TIME_PRESETS = {
+  dawn: { hour: 6, label: 'Dawn' },
+  midday: { hour: 12, label: 'Midday' },
+  dusk: { hour: 18.5, label: 'Dusk' },
+  night: { hour: 23, label: 'Night' }
+};
+
+const TIME_KEYS = [
+  'setHour',
+  'getHour',
+  'current',
+  'setPreset',
+  'dawn',
+  'midday',
+  'dusk',
+  'night',
+  'presets',
+  'help'
+];
+
+const ensureDevtoolsRoot = () => {
+  if (typeof window === 'undefined') return null;
+  if (!window.Devtools || typeof window.Devtools !== 'object') {
+    window.Devtools = {};
+  }
+  return window.Devtools;
+};
+
+export const registerTimeDevtools = ({ getTimeOfDayHours, setTimeOfDayHours }) => {
+  if (typeof window === 'undefined') return () => {};
+  if (typeof setTimeOfDayHours !== 'function' || typeof getTimeOfDayHours !== 'function') {
+    return () => {};
+  }
+
+  const root = ensureDevtoolsRoot();
+  if (!root) return () => {};
+
+  const timeApi = root.time || (root.time = {});
+  const previous = {};
+
+  TIME_KEYS.forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(timeApi, key)) {
+      previous[key] = timeApi[key];
+    }
+  });
+
+  const describeHour = (hour) => {
+    const seconds = hour * SECONDS_PER_HOUR;
+    return `${formatGameClock(seconds)} (${hour.toFixed(2)}h)`;
+  };
+
+  const applyHour = (value) => {
+    const normalized = setTimeOfDayHours(value);
+    const currentHour = getTimeOfDayHours();
+    const resolved = Number.isFinite(normalized) ? normalized : currentHour;
+    const display = Number.isFinite(resolved) ? describeHour(resolved) : 'unknown';
+    try {
+      console.info(`[Devtools.time] Time set to ${display}.`);
+    } catch (_) {}
+    return resolved;
+  };
+
+  const applyPreset = (name) => {
+    if (typeof name !== 'string') {
+      return applyHour(name);
+    }
+    const key = name.toLowerCase();
+    const preset = TIME_PRESETS[key];
+    if (!preset) {
+      const available = Object.keys(TIME_PRESETS).join(', ');
+      try {
+        console.warn(`[Devtools.time] Unknown preset "${name}". Available presets: ${available}.`);
+      } catch (_) {}
+      return getTimeOfDayHours();
+    }
+    try {
+      console.info(`[Devtools.time] Applying preset ${preset.label}.`);
+    } catch (_) {}
+    return applyHour(preset.hour);
+  };
+
+  timeApi.setHour = (value) => applyHour(value);
+  timeApi.getHour = () => getTimeOfDayHours();
+  timeApi.current = timeApi.getHour;
+  timeApi.setPreset = (name) => applyPreset(name);
+  timeApi.dawn = () => applyPreset('dawn');
+  timeApi.midday = () => applyPreset('midday');
+  timeApi.dusk = () => applyPreset('dusk');
+  timeApi.night = () => applyPreset('night');
+  timeApi.presets = { ...TIME_PRESETS };
+  timeApi.help = () => {
+    const names = Object.keys(TIME_PRESETS).join(', ');
+    return `Devtools.time controls: setHour(number), setPreset(name), presets: ${names}. Shortcut methods available for each preset.`;
+  };
+
+  return () => {
+    TIME_KEYS.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(previous, key)) {
+        timeApi[key] = previous[key];
+      } else {
+        delete timeApi[key];
+      }
+    });
+    if (Object.keys(timeApi).length === 0 && root.time === timeApi) {
+      delete root.time;
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- expose a Devtools.time console module with presets for dawn, midday, dusk, and night
- allow the game time hook to accept manual hour overrides for tooling
- wire OpenWorldGame to register the new devtools helpers and log the addition in changes.md

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0065b98048332b4acebc8c3552055