### PR TITLE
Align Naruto and Shikamaru NPC spawn and patrol routes

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -49,3 +49,5 @@ Recent
 - World: Kitbashed building windows now glow at night with randomized late-night lights-out behavior tied to the day/night cycle.
 
 - Devtools: Added console helpers to jump the world clock to dawn, midday, dusk, or night presets.
+
+- NPCs: Naruto now patrols Konoha roads from MO382 and Shikamaru roams the Nara District after spawning at RJ416.

--- a/src/game/npcs/behaviors/roadPatrol.js
+++ b/src/game/npcs/behaviors/roadPatrol.js
@@ -1,0 +1,290 @@
+import * as THREE from 'three';
+import { resolveCollisions } from '/src/game/player/movement/collision.js';
+import { loadKonohaRoads } from '/src/components/game/objects/konoha_roads.js';
+import { WORLD_SIZE } from '/src/scene/terrain.js';
+
+const WORLD_HALF = WORLD_SIZE / 2;
+
+function toWorldPoint(point) {
+  if (!Array.isArray(point) || point.length < 2) return null;
+  const x = (Number(point[0]) / 100) * WORLD_SIZE - WORLD_HALF;
+  const z = (Number(point[1]) / 100) * WORLD_SIZE - WORLD_HALF;
+  return { x, z };
+}
+
+function dist2(x1, z1, x2, z2) {
+  const dx = x2 - x1;
+  const dz = z2 - z1;
+  return dx * dx + dz * dz;
+}
+
+function segmentProjection(px, pz, segment) {
+  const ax = segment.start.x;
+  const az = segment.start.z;
+  const bx = segment.end.x;
+  const bz = segment.end.z;
+  const vx = bx - ax;
+  const vz = bz - az;
+  const len2 = vx * vx + vz * vz;
+  if (len2 === 0) {
+    return { point: { x: ax, z: az }, t: 0, dist2: dist2(px, pz, ax, az) };
+  }
+  const t = ((px - ax) * vx + (pz - az) * vz) / len2;
+  const clamped = Math.max(0, Math.min(1, t));
+  const projX = ax + vx * clamped;
+  const projZ = az + vz * clamped;
+  return { point: { x: projX, z: projZ }, t: clamped, dist2: dist2(px, pz, projX, projZ) };
+}
+
+function makeNodeKey(point) {
+  return `${point.x.toFixed(2)},${point.z.toFixed(2)}`;
+}
+
+function ensureWalkingAnimation(npcGroup) {
+  const actions = npcGroup?.userData?.animations;
+  if (!actions) return;
+  const walkingAction = actions.running || actions.runFast || actions.walking || actions.casualWalk;
+  if (!walkingAction) return;
+  if (npcGroup.userData.currentAnimation === walkingAction._clip?.name) return;
+  try {
+    Object.values(actions).forEach((action) => action.stop());
+    walkingAction.reset();
+    walkingAction.setLoop(THREE.LoopRepeat);
+    walkingAction.play();
+    npcGroup.userData.currentAnimation = walkingAction._clip?.name || 'walking';
+  } catch (_) {}
+}
+
+function ensureIdleAnimation(npcGroup) {
+  const actions = npcGroup?.userData?.animations;
+  if (!actions) return;
+  const idle = actions.idle12 || actions.idle11 || actions.idle || actions.casualWalk;
+  if (!idle) return;
+  try {
+    Object.values(actions).forEach((action) => action.stop());
+    idle.reset();
+    idle.setLoop(THREE.LoopRepeat);
+    idle.play();
+    npcGroup.userData.currentAnimation = idle._clip?.name || 'idle';
+  } catch (_) {}
+}
+
+function pickRandom(items) {
+  if (!Array.isArray(items) || !items.length) return null;
+  return items[Math.floor(Math.random() * items.length)];
+}
+
+function buildRoadNetwork(roads, minWidth = 3) {
+  const segments = [];
+  const nodes = new Map();
+  const addNode = (key, point, segment, dir) => {
+    const entry = nodes.get(key) || { point, links: [] };
+    entry.links.push({ segment, dir });
+    nodes.set(key, entry);
+  };
+
+  for (const road of roads || []) {
+    const width = Number(road.width || 0);
+    if (width < minWidth) continue;
+    const pts = Array.isArray(road.points) ? road.points.map(toWorldPoint).filter(Boolean) : [];
+    for (let i = 0; i < pts.length - 1; i++) {
+      const start = pts[i];
+      const end = pts[i + 1];
+      if (!start || !end) continue;
+      const dx = end.x - start.x;
+      const dz = end.z - start.z;
+      const length = Math.hypot(dx, dz);
+      if (!Number.isFinite(length) || length <= 0.5) continue;
+      const segment = {
+        start,
+        end,
+        startKey: makeNodeKey(start),
+        endKey: makeNodeKey(end),
+        length,
+      };
+      segments.push(segment);
+      addNode(segment.startKey, start, segment, 1);
+      addNode(segment.endKey, end, segment, -1);
+    }
+  }
+
+  return { segments, nodes };
+}
+
+function nearestSegment(position, segments) {
+  let best = null;
+  let bestDist = Infinity;
+  for (const segment of segments) {
+    const proj = segmentProjection(position.x, position.z, segment);
+    if (proj.dist2 < bestDist) {
+      bestDist = proj.dist2;
+      best = { segment, projection: proj };
+    }
+  }
+  return best;
+}
+
+function chooseNextSegment(ai, currentNodeKey) {
+  if (!currentNodeKey) return null;
+  const node = ai.nodes.get(currentNodeKey);
+  if (!node || !node.links.length) return null;
+  const alternatives = node.links.filter((link) => link.segment !== ai.currentSegment);
+  const pool = alternatives.length ? alternatives : node.links;
+  return pickRandom(pool);
+}
+
+function setTarget(ai, npcGroup, targetPoint) {
+  if (!targetPoint) return;
+  ai.targetPoint = { x: targetPoint.x, z: targetPoint.z };
+  ensureWalkingAnimation(npcGroup);
+}
+
+function handleArrival(ai, npcGroup) {
+  if (ai.mode === 'approach') {
+    ai.mode = 'patrol';
+    if (!ai.currentSegment) return;
+    const nextPoint = ai.travelDir > 0 ? ai.currentSegment.end : ai.currentSegment.start;
+    setTarget(ai, npcGroup, nextPoint);
+    return;
+  }
+
+  if (!ai.currentSegment) return;
+  const pauseChance = ai.pauseChance ?? 0.5;
+  if (Math.random() < pauseChance) {
+    ai.wait = ai.pauseMin + Math.random() * (ai.pauseMax - ai.pauseMin);
+    ensureIdleAnimation(npcGroup);
+  }
+
+  const arrivedKey = ai.travelDir > 0 ? ai.currentSegment.endKey : ai.currentSegment.startKey;
+  const next = chooseNextSegment(ai, arrivedKey);
+  if (!next) {
+    ai.travelDir *= -1;
+    const fallbackPoint = ai.travelDir > 0 ? ai.currentSegment.end : ai.currentSegment.start;
+    setTarget(ai, npcGroup, fallbackPoint);
+    return;
+  }
+
+  ai.currentSegment = next.segment;
+  ai.travelDir = next.dir;
+  const destination = ai.travelDir > 0 ? ai.currentSegment.end : ai.currentSegment.start;
+  setTarget(ai, npcGroup, destination);
+}
+
+export function attachRoadPatrol(npcGroup, options = {}) {
+  const speed = Math.max(2, Math.min(20, options.speed || 8));
+  const pauseMin = Math.max(0, options.pauseMin ?? 1.5);
+  const pauseMax = Math.max(pauseMin, options.pauseMax ?? 4);
+  const pauseChance = Math.max(0, Math.min(1, options.pauseChance ?? 0.35));
+  const radius = Math.max(1.2, Math.min(3.0, options.radius || (npcGroup.userData?.collider?.radius ?? 2.0)));
+  const fallback = typeof options.onError === 'function' ? options.onError : null;
+
+  npcGroup.userData.ai = {
+    type: 'roadPatrol',
+    speed,
+    radius,
+    wait: 0,
+    pauseMin,
+    pauseMax,
+    pauseChance,
+    targetPoint: null,
+    currentSegment: null,
+    travelDir: 1,
+    mode: 'init',
+    pendingTarget: null,
+    segments: [],
+    nodes: new Map(),
+    ready: false,
+  };
+
+  loadKonohaRoads()
+    .then(({ roads }) => {
+      const { segments, nodes } = buildRoadNetwork(roads?.all || [], options.minRoadWidth || 3);
+      if (!segments.length) {
+        if (fallback) fallback();
+        return;
+      }
+      const ai = npcGroup.userData.ai;
+      if (!ai || ai.type !== 'roadPatrol') return;
+      ai.segments = segments;
+      ai.nodes = nodes;
+      ai.ready = true;
+      const nearest = nearestSegment(npcGroup.position, segments);
+      if (nearest) {
+        ai.currentSegment = nearest.segment;
+        ai.mode = 'approach';
+        ai.travelDir = Math.random() < 0.5 ? 1 : -1;
+        ai.pendingTarget = ai.travelDir > 0 ? nearest.segment.end : nearest.segment.start;
+        setTarget(ai, npcGroup, nearest.projection.point);
+      }
+    })
+    .catch(() => {
+      if (fallback) fallback();
+    });
+}
+
+export function updateRoadPatrol(npcGroup, delta, objectGrid) {
+  const ai = npcGroup?.userData?.ai;
+  if (!ai || ai.type !== 'roadPatrol') return;
+
+  if (ai.wait > 0) {
+    ai.wait -= delta;
+    if (ai.wait <= 0) {
+      ai.wait = 0;
+      ensureWalkingAnimation(npcGroup);
+    }
+    return;
+  }
+
+  if (!ai.ready || !ai.currentSegment) return;
+  if (!ai.targetPoint) {
+    handleArrival(ai, npcGroup);
+    if (!ai.targetPoint) return;
+  }
+
+  const dx = ai.targetPoint.x - npcGroup.position.x;
+  const dz = ai.targetPoint.z - npcGroup.position.z;
+  const distance = Math.hypot(dx, dz);
+  if (distance < 0.05) {
+    if (ai.mode === 'approach' && ai.pendingTarget) {
+      setTarget(ai, npcGroup, ai.pendingTarget);
+      ai.mode = 'patrol';
+      ai.pendingTarget = null;
+      return;
+    }
+    handleArrival(ai, npcGroup);
+    return;
+  }
+
+  const step = ai.speed * delta;
+  const normX = dx / (distance || 1);
+  const normZ = dz / (distance || 1);
+  const moveX = npcGroup.position.x + normX * Math.min(step, distance);
+  const moveZ = npcGroup.position.z + normZ * Math.min(step, distance);
+
+  const intended = { x: moveX, z: moveZ };
+  const restoreFlag = npcGroup.userData.__ignoreCollision;
+  npcGroup.userData.__ignoreCollision = true;
+  const resolved = resolveCollisions(intended, ai.radius, objectGrid);
+  npcGroup.userData.__ignoreCollision = restoreFlag;
+
+  npcGroup.position.x = resolved.x;
+  npcGroup.position.z = resolved.z;
+
+  try {
+    const model = npcGroup.userData.model || npcGroup.children?.[0];
+    if (model && distance > 0.01) {
+      model.rotation.y = Math.atan2(normX, normZ);
+    }
+  } catch (_) {}
+
+  if (Math.hypot(ai.targetPoint.x - npcGroup.position.x, ai.targetPoint.z - npcGroup.position.z) < 0.3) {
+    if (ai.mode === 'approach' && ai.pendingTarget) {
+      setTarget(ai, npcGroup, ai.pendingTarget);
+      ai.mode = 'patrol';
+      ai.pendingTarget = null;
+    } else {
+      handleArrival(ai, npcGroup);
+    }
+  }
+}
+

--- a/src/game/npcs/behaviors/wanderFree.js
+++ b/src/game/npcs/behaviors/wanderFree.js
@@ -1,6 +1,97 @@
 import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
 
+function normalizePolygon(points) {
+  if (!Array.isArray(points)) return null;
+  const poly = points
+    .map((point) => {
+      if (!point) return null;
+      if (Array.isArray(point) && point.length >= 2) {
+        const x = Number(point[0]);
+        const z = Number(point[1]);
+        if (!Number.isFinite(x) || !Number.isFinite(z)) return null;
+        return { x, z };
+      }
+      if (typeof point === 'object' && Number.isFinite(point.x) && Number.isFinite(point.z)) {
+        return { x: Number(point.x), z: Number(point.z) };
+      }
+      return null;
+    })
+    .filter(Boolean);
+  return poly.length >= 3 ? poly : null;
+}
+
+function polygonCentroid(points) {
+  if (!Array.isArray(points) || points.length < 3) return null;
+  let area = 0;
+  let cx = 0;
+  let cz = 0;
+  const n = points.length;
+  for (let i = 0; i < n; i++) {
+    const { x: x1, z: z1 } = points[i];
+    const { x: x2, z: z2 } = points[(i + 1) % n];
+    const cross = x1 * z2 - x2 * z1;
+    area += cross;
+    cx += (x1 + x2) * cross;
+    cz += (z1 + z2) * cross;
+  }
+  area *= 0.5;
+  if (Math.abs(area) < 1e-5) {
+    const avg = points.reduce(
+      (acc, p) => ({ x: acc.x + p.x, z: acc.z + p.z }),
+      { x: 0, z: 0 }
+    );
+    return { x: avg.x / n, z: avg.z / n };
+  }
+  return { x: cx / (6 * area), z: cz / (6 * area) };
+}
+
+function pointInPolygon(x, z, polygon) {
+  if (!Array.isArray(polygon) || polygon.length < 3) return true;
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x;
+    const zi = polygon[i].z;
+    const xj = polygon[j].x;
+    const zj = polygon[j].z;
+    const intersect = ((zi > z) !== (zj > z)) && (x < (xj - xi) * (z - zi) / (zj - zi + 1e-9) + xi);
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+function projectOnSegment(px, pz, ax, az, bx, bz) {
+  const vx = bx - ax;
+  const vz = bz - az;
+  const len2 = vx * vx + vz * vz;
+  if (len2 <= 1e-9) {
+    return { x: ax, z: az, dist2: (px - ax) * (px - ax) + (pz - az) * (pz - az) };
+  }
+  const t = ((px - ax) * vx + (pz - az) * vz) / len2;
+  const clamped = Math.max(0, Math.min(1, t));
+  const x = ax + vx * clamped;
+  const z = az + vz * clamped;
+  const dx = px - x;
+  const dz = pz - z;
+  return { x, z, dist2: dx * dx + dz * dz };
+}
+
+function nearestPointOnPolygon(px, pz, polygon) {
+  if (!Array.isArray(polygon) || polygon.length < 1) return null;
+  let best = null;
+  let bestDist = Infinity;
+  for (let i = 0; i < polygon.length; i++) {
+    const a = polygon[i];
+    const b = polygon[(i + 1) % polygon.length];
+    const proj = projectOnSegment(px, pz, a.x, a.z, b.x, b.z);
+    if (proj.dist2 < bestDist) {
+      best = { x: proj.x, z: proj.z };
+      bestDist = proj.dist2;
+    }
+  }
+  return best;
+}
+
 function randDir() {
   const a = Math.random() * Math.PI * 2;
   return { x: Math.sin(a), z: Math.cos(a) };
@@ -13,6 +104,16 @@ export function attachWanderFree(npcGroup, options = {}) {
   const pauseChance = Math.max(0, Math.min(1, options.pauseChance ?? 0.6));
   const dirChangeMin = Math.max(0.5, options.dirChangeMin ?? 3);
   const dirChangeMax = Math.max(dirChangeMin, options.dirChangeMax ?? 6);
+
+  const polygon = normalizePolygon(options.keepWithinPolygon);
+  const centroid = polygon ? polygonCentroid(polygon) : null;
+  if (polygon && !pointInPolygon(npcGroup.position.x, npcGroup.position.z, polygon)) {
+    const fallback = nearestPointOnPolygon(npcGroup.position.x, npcGroup.position.z, polygon) || centroid;
+    if (fallback) {
+      npcGroup.position.x = fallback.x;
+      npcGroup.position.z = fallback.z;
+    }
+  }
 
   npcGroup.userData.ai = {
     type: 'wanderFree',
@@ -29,12 +130,25 @@ export function attachWanderFree(npcGroup, options = {}) {
     pauseChance,
     dirChangeMin,
     dirChangeMax,
+    polygon,
+    polygonCentroid: centroid,
   };
 }
 
 export function updateWanderFree(npcGroup, delta, objectGrid) {
   const ai = npcGroup?.userData?.ai;
   if (!ai || ai.type !== 'wanderFree') return;
+
+  if (ai.polygon && !pointInPolygon(npcGroup.position.x, npcGroup.position.z, ai.polygon)) {
+    const fallback = nearestPointOnPolygon(npcGroup.position.x, npcGroup.position.z, ai.polygon) || ai.polygonCentroid;
+    if (fallback) {
+      npcGroup.position.x = fallback.x;
+      npcGroup.position.z = fallback.z;
+      ai.dir = randDir();
+      ai.wait = 0.1;
+      ai.changeIn = ai.dirChangeMin || 1.5;
+    }
+  }
 
   // Reduce conversation cooldown each frame
   if (ai.convoCooldown > 0) ai.convoCooldown -= delta;
@@ -225,6 +339,19 @@ export function updateWanderFree(npcGroup, delta, objectGrid) {
     ai.dir = randDir();
     ai.wait = 0.2 + Math.random() * 0.4;
     return;
+  }
+
+  if (ai.polygon && !pointInPolygon(resolved.x, resolved.z, ai.polygon)) {
+    const fallback = nearestPointOnPolygon(npcGroup.position.x, npcGroup.position.z, ai.polygon) || ai.polygonCentroid;
+    if (fallback) {
+      const toX = fallback.x - npcGroup.position.x;
+      const toZ = fallback.z - npcGroup.position.z;
+      const len = Math.hypot(toX, toZ) || 1;
+      ai.dir = { x: toX / len, z: toZ / len };
+      ai.wait = 0;
+      ai.changeIn = Math.max(0.5, Math.min(ai.changeIn, ai.dirChangeMin || 1.5));
+      return;
+    }
   }
 
   npcGroup.position.x = resolved.x;

--- a/src/game/npcs/naruto.js
+++ b/src/game/npcs/naruto.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { createNpcRig } from './common.js';
 import { attachWanderFree } from './behaviors/wanderFree.js';
+import { attachRoadPatrol } from './behaviors/roadPatrol.js';
 import { getPlayerIdentity } from '../player/identity.js';
 
 export function createNaruto(scene, settings, position = new THREE.Vector3()) {
@@ -41,8 +42,18 @@ export function createNaruto(scene, settings, position = new THREE.Vector3()) {
         } catch (_) {}
       };
     } catch (_) {}
-    // Give Naruto free-wander behavior
-    try { attachWanderFree(group, { speed: 8 }); } catch (_) {}
+    // Give Naruto a road-focused patrol; fall back to free wander if unavailable
+    try {
+      attachRoadPatrol(group, {
+        speed: 8,
+        pauseChance: 0.25,
+        onError: () => {
+          try { attachWanderFree(group, { speed: 8 }); } catch (_) {}
+        }
+      });
+    } catch (_) {
+      try { attachWanderFree(group, { speed: 8 }); } catch (_) {}
+    }
     return group;
   });
 }

--- a/src/game/npcs/shikamaru.js
+++ b/src/game/npcs/shikamaru.js
@@ -2,6 +2,24 @@ import * as THREE from 'three';
 import { createNpcRig } from './common.js';
 import { attachWanderFree } from './behaviors/wanderFree.js';
 import { getPlayerIdentity } from '../player/identity.js';
+import { loadKonohaRoads } from '/src/components/game/objects/konoha_roads.js';
+import { WORLD_SIZE } from '/src/scene/terrain.js';
+
+const WORLD_HALF = WORLD_SIZE / 2;
+
+function districtPolygonToWorld(points) {
+  if (!Array.isArray(points)) return null;
+  const poly = points
+    .map((point) => {
+      if (!Array.isArray(point) || point.length < 2) return null;
+      const x = (Number(point[0]) / 100) * WORLD_SIZE - WORLD_HALF;
+      const z = (Number(point[1]) / 100) * WORLD_SIZE - WORLD_HALF;
+      if (!Number.isFinite(x) || !Number.isFinite(z)) return null;
+      return { x, z };
+    })
+    .filter(Boolean);
+  return poly.length >= 3 ? poly : null;
+}
 
 export function createShikamaru(scene, settings, position = new THREE.Vector3()) {
   return createNpcRig({
@@ -41,8 +59,23 @@ export function createShikamaru(scene, settings, position = new THREE.Vector3())
         } catch (_) {}
       };
     } catch (_) {}
-    // Wander freely across the map with collision
-    try { attachWanderFree(group, { speed: 8 }); } catch (_) {}
+    const applyWander = (polygon) => {
+      const options = { speed: 8 };
+      if (polygon) {
+        options.keepWithinPolygon = polygon;
+      }
+      try { attachWanderFree(group, options); } catch (_) {}
+    };
+
+    loadKonohaRoads()
+      .then(({ districts }) => {
+        const district = districts?.Nara || districts?.nara;
+        const polygon = districtPolygonToWorld(district?.points);
+        applyWander(polygon);
+      })
+      .catch(() => {
+        applyWander(null);
+      });
     return group;
   });
 }

--- a/src/hooks/sceneLifecycle.js
+++ b/src/hooks/sceneLifecycle.js
@@ -8,6 +8,8 @@ import { createShikamaru } from '../game/npcs/shikamaru.js';
 import { createNeji } from '../game/npcs/neji.js';
 import { createOrochimaru } from '../game/npcs/orochimaru.js';
 import { getPlayerIdentity } from '../game/player/identity.js';
+import { parseGridLabel, posForCell } from '../game/objects/utils/gridLabel.js';
+import { WORLD_SIZE } from '../scene/terrain.js';
 
 export function initThreeScene({
   mountRef,
@@ -60,10 +62,10 @@ export function initThreeScene({
             }
 
             const spawnEntries = [
-              { key: 'naruto', label: 'Naruto', offset: new THREE.Vector3(6, 0, 0), create: createNaruto },
+              { key: 'naruto', label: 'Naruto', spawnLabel: 'MO382', create: createNaruto },
               { key: 'sasuke', label: 'Sasuke', offset: new THREE.Vector3(-6, 0, 0), create: createSasuke },
               { key: 'sakura', label: 'Sakura', offset: new THREE.Vector3(0, 0, 6), create: createSakura },
-              { key: 'shikamaru', label: 'Shikamaru', offset: new THREE.Vector3(0, 0, -6), create: createShikamaru },
+              { key: 'shikamaru', label: 'Shikamaru', spawnLabel: 'RJ416', create: createShikamaru },
               { key: 'neji', label: 'Neji', offset: new THREE.Vector3(8, 0, 8), create: createNeji },
               { key: 'orochimaru', label: 'Orochimaru', offset: new THREE.Vector3(-8, 0, 8), create: createOrochimaru }
             ];
@@ -78,8 +80,20 @@ export function initThreeScene({
             }
 
             const spawnPromises = activeEntries.map((entry) => {
-              const targetPosition = base.clone().add(entry.offset.clone());
-              return entry.create(scene, { shadows: settings.shadows }, targetPosition);
+              let targetPosition = base.clone();
+              if (entry.spawnLabel) {
+                try {
+                  const { i, j } = parseGridLabel(entry.spawnLabel);
+                  targetPosition = posForCell(i, j, WORLD_SIZE);
+                } catch (_) {
+                  try {
+                    targetPosition.add(entry.offset ? entry.offset.clone() : new THREE.Vector3());
+                  } catch (_) {}
+                }
+              } else if (entry.offset) {
+                targetPosition.add(entry.offset.clone());
+              }
+              return entry.create(scene, { shadows: settings.shadows }, targetPosition.clone());
             });
 
             if (!spawnPromises.length) {

--- a/src/scene/animationLoop.js
+++ b/src/scene/animationLoop.js
@@ -1,6 +1,7 @@
 import * as TWEEN from '@tweenjs/tween.js';
 import { updatePlayer } from '../game/player/index.js';
 import { updateWanderFree } from '/src/game/npcs/behaviors/wanderFree.js';
+import { updateRoadPatrol } from '/src/game/npcs/behaviors/roadPatrol.js';
 import { INTERACTION_DISTANCE } from '../game/constants.js';
 import { multiplayerManager } from '../network/multiplayerManager.js';
 
@@ -317,6 +318,7 @@ export function startAnimationLoop({
                     } catch (_) {}
                     // Per-NPC behavior (free wander attached to Shikamaru only)
                     try { updateWanderFree(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateRoadPatrol(g, delta, objectGridRef.current); } catch (_) {}
                     // Ensure mixer advances regardless
                     try { g?.userData?.mixer?.update(delta); } catch (_) {}
                 }


### PR DESCRIPTION
## Summary
- spawn Naruto at MO382 and attach a road-focused patrol built from the Konoha road network
- spawn Shikamaru at RJ416 and constrain his wander loop to the mapped Nara District polygon
- extend NPC wander logic to support polygon bounds and add a reusable roadPatrol helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00a754fd48332bbd7dfc71405216c