### PR TITLE
Refine Naruto and Shikamaru roaming behaviors

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -51,3 +51,5 @@ Recent
 - Devtools: Added console helpers to jump the world clock to dawn, midday, dusk, or night presets.
 
 - NPCs: Naruto now patrols Konoha roads from MO382 and Shikamaru roams the Nara District after spawning at RJ416.
+- NPCs: Naruto alternates full road loops with ramen-side loitering, swapping between walk and run patrols after each wander.
+- NPCs: Shikamaru now follows the Nara district road grid with fallbacks to free roaming so he explores instead of pacing.

--- a/src/game/npcs/behaviors/narutoRoutine.js
+++ b/src/game/npcs/behaviors/narutoRoutine.js
@@ -1,0 +1,271 @@
+import * as THREE from 'three';
+import { resolveCollisions } from '/src/game/player/movement/collision.js';
+import { attachRoadPatrol } from './roadPatrol.js';
+import { attachWanderFree } from './wanderFree.js';
+
+const WALK_PATROL_SPEED = 8;
+const RUN_PATROL_SPEED = 13;
+const RETURN_WALK_SPEED = 8.5;
+const RETURN_RUN_SPEED = 11.5;
+const RETURN_TOLERANCE = 1.75;
+const WANDER_SPEED = 6.5;
+const WANDER_DURATION_MIN = 30;
+const WANDER_DURATION_MAX = 70;
+const WANDER_RADIUS = 18;
+const WANDER_CENTER_JITTER = 8;
+const MODE_POOL = ['walk', 'run'];
+
+function shuffle(array) {
+  const arr = array.slice();
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function createCirclePolygon(center, radius, steps = 14) {
+  const points = [];
+  for (let i = 0; i < steps; i++) {
+    const angle = (i / steps) * Math.PI * 2;
+    points.push({
+      x: center.x + Math.cos(angle) * radius,
+      z: center.z + Math.sin(angle) * radius,
+    });
+  }
+  return points;
+}
+
+function playAnimationFromCandidates(npcGroup, candidates) {
+  const actions = npcGroup?.userData?.animations;
+  if (!actions) return false;
+  for (let i = 0; i < candidates.length; i++) {
+    const key = candidates[i];
+    const action = actions[key];
+    if (!action) continue;
+    const current = npcGroup.userData.currentAnimation;
+    if (current === key || current === action._clip?.name) return true;
+    try {
+      Object.values(actions).forEach((a) => a.stop());
+      action.reset();
+      action.setLoop(THREE.LoopRepeat);
+      action.play();
+      npcGroup.userData.currentAnimation = key;
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function playMoveAnimation(npcGroup, style) {
+  if (style === 'run') {
+    playAnimationFromCandidates(npcGroup, ['running', 'runFast', 'walking', 'casualWalk']);
+  } else {
+    playAnimationFromCandidates(npcGroup, ['walking', 'casualWalk', 'running', 'runFast']);
+  }
+}
+
+function playIdleAnimation(npcGroup) {
+  playAnimationFromCandidates(npcGroup, ['idle12', 'idle11', 'idle', 'casualWalk']);
+}
+
+function ensureModeQueue(routine) {
+  if (!Array.isArray(routine.modeQueue) || routine.modeQueue.length === 0) {
+    routine.modeQueue = shuffle(MODE_POOL);
+  }
+}
+
+function takeNextPatrolMode(routine) {
+  ensureModeQueue(routine);
+  if (!Array.isArray(routine.modeQueue) || routine.modeQueue.length === 0) {
+    return routine.lastPatrolMode === 'run' ? 'walk' : 'run';
+  }
+  let next = routine.modeQueue.shift();
+  if (next === routine.lastPatrolMode && routine.modeQueue.length > 0) {
+    const alt = routine.modeQueue.shift();
+    routine.modeQueue.push(next);
+    next = alt;
+  }
+  if (!next) {
+    next = routine.lastPatrolMode === 'run' ? 'walk' : 'run';
+  }
+  return next;
+}
+
+function startWander(npcGroup, routine, overrideDuration = null) {
+  routine.state = 'wandering';
+  routine.loopTriggered = false;
+  routine.returnFromMode = null;
+  const duration = overrideDuration ?? (routine.wanderMin + Math.random() * (routine.wanderMax - routine.wanderMin));
+  routine.wanderTimer = duration;
+
+  const center = routine.spawn.clone();
+  if (WANDER_CENTER_JITTER > 0) {
+    center.x += (Math.random() - 0.5) * WANDER_CENTER_JITTER;
+    center.z += (Math.random() - 0.5) * WANDER_CENTER_JITTER;
+  }
+  const polygon = createCirclePolygon(center, routine.wanderRadius);
+  routine.currentWanderPolygon = polygon;
+
+  try {
+    attachWanderFree(npcGroup, {
+      speed: WANDER_SPEED,
+      pauseChance: 0.65,
+      pauseMin: 1.5,
+      pauseMax: 4.5,
+      dirChangeMin: 2.5,
+      dirChangeMax: 5.5,
+      keepWithinPolygon: polygon,
+    });
+  } catch (_) {
+    npcGroup.userData.ai = { type: 'narutoIdle' };
+  }
+}
+
+function startPatrol(npcGroup, routine, mode) {
+  routine.state = 'patrol';
+  routine.loopTriggered = false;
+  routine.returnFromMode = mode;
+  routine.lastPatrolMode = mode;
+  routine.currentPatrolMode = mode;
+
+  const speed = mode === 'run' ? RUN_PATROL_SPEED : WALK_PATROL_SPEED;
+  const pauseChance = mode === 'run' ? 0.1 : 0.32;
+  const pauseMin = mode === 'run' ? 0.5 : 1.5;
+  const pauseMax = mode === 'run' ? 1.6 : 4.2;
+  const minSegments = mode === 'run' ? 8 : 6;
+
+  const fallbackToWander = () => {
+    startWander(npcGroup, routine, 40);
+  };
+
+  try {
+    attachRoadPatrol(npcGroup, {
+      speed,
+      pauseChance,
+      pauseMin,
+      pauseMax,
+      loop: {
+        minSegments,
+        onComplete: () => {
+          if (!routine.loopTriggered && routine.state === 'patrol') {
+            routine.loopTriggered = true;
+          }
+        },
+      },
+      onError: fallbackToWander,
+    });
+  } catch (_) {
+    fallbackToWander();
+  }
+}
+
+function startReturn(npcGroup, routine) {
+  routine.state = 'returning';
+  routine.loopTriggered = false;
+  const speed = routine.returnFromMode === 'run' ? RETURN_RUN_SPEED : RETURN_WALK_SPEED;
+  routine.returnSpeed = speed;
+  routine.returnTolerance = routine.returnTolerance || RETURN_TOLERANCE;
+  npcGroup.userData.ai = {
+    type: 'narutoReturn',
+    speed,
+    radius: npcGroup.userData?.collider?.radius ?? 2.0,
+  };
+  playMoveAnimation(npcGroup, routine.returnFromMode === 'run' ? 'run' : 'walk');
+}
+
+export function attachNarutoRoutine(npcGroup, options = {}) {
+  if (!npcGroup) return;
+  const spawn = options.spawnPosition && options.spawnPosition.isVector3
+    ? options.spawnPosition.clone()
+    : npcGroup.position.clone();
+  const routine = {
+    state: 'init',
+    spawn,
+    wanderRadius: Math.max(8, options.wanderRadius || WANDER_RADIUS),
+    wanderMin: Math.max(10, options.wanderMin ?? WANDER_DURATION_MIN),
+    wanderMax: Math.max(options.wanderMin ?? WANDER_DURATION_MIN, options.wanderMax ?? WANDER_DURATION_MAX),
+    returnTolerance: options.returnTolerance ?? RETURN_TOLERANCE,
+    modeQueue: [],
+    loopTriggered: false,
+    wanderTimer: 0,
+    returnFromMode: null,
+    lastPatrolMode: null,
+  };
+  npcGroup.userData.__narutoRoutine = routine;
+  startPatrol(npcGroup, routine, 'walk');
+}
+
+export function updateNarutoRoutine(npcGroup, delta, objectGrid) {
+  const routine = npcGroup?.userData?.__narutoRoutine;
+  if (!routine) return;
+  if (npcGroup.userData?.interacting) {
+    playIdleAnimation(npcGroup);
+    return;
+  }
+
+  if (routine.state === 'patrol') {
+    if (routine.loopTriggered) {
+      startReturn(npcGroup, routine);
+    }
+    return;
+  }
+
+  if (routine.state === 'returning') {
+    const ai = npcGroup.userData?.ai;
+    if (!ai || ai.type !== 'narutoReturn') {
+      startReturn(npcGroup, routine);
+      return;
+    }
+
+    const target = routine.spawn;
+    const dx = target.x - npcGroup.position.x;
+    const dz = target.z - npcGroup.position.z;
+    const distance = Math.hypot(dx, dz);
+    if (distance <= (routine.returnTolerance || RETURN_TOLERANCE)) {
+      playIdleAnimation(npcGroup);
+      startWander(npcGroup, routine);
+      return;
+    }
+
+    const speed = ai.speed || routine.returnSpeed || RETURN_WALK_SPEED;
+    const step = Math.min(speed * delta, distance);
+    const normX = dx / (distance || 1);
+    const normZ = dz / (distance || 1);
+    const intended = {
+      x: npcGroup.position.x + normX * step,
+      z: npcGroup.position.z + normZ * step,
+    };
+    const restore = npcGroup.userData.__ignoreCollision;
+    npcGroup.userData.__ignoreCollision = true;
+    const resolved = resolveCollisions(intended, ai.radius || npcGroup.userData?.collider?.radius || 2.0, objectGrid);
+    npcGroup.userData.__ignoreCollision = restore;
+    npcGroup.position.x = resolved.x;
+    npcGroup.position.z = resolved.z;
+
+    try {
+      const model = npcGroup.userData.model || npcGroup.children?.[0];
+      if (model && distance > 0.01) {
+        model.rotation.y = Math.atan2(normX, normZ);
+      }
+    } catch (_) {}
+
+    playMoveAnimation(npcGroup, speed >= ((RUN_PATROL_SPEED + WALK_PATROL_SPEED) / 2) ? 'run' : 'walk');
+    return;
+  }
+
+  if (routine.state === 'wandering') {
+    if (routine.wanderTimer > 0) {
+      routine.wanderTimer -= delta;
+    }
+    if (routine.wanderTimer <= 0) {
+      routine.wanderTimer = 0;
+      npcGroup.userData.ai = null;
+      playIdleAnimation(npcGroup);
+      const nextMode = takeNextPatrolMode(routine);
+      startPatrol(npcGroup, routine, nextMode);
+    }
+  }
+}

--- a/src/game/npcs/behaviors/roadPatrol.js
+++ b/src/game/npcs/behaviors/roadPatrol.js
@@ -12,6 +12,27 @@ function toWorldPoint(point) {
   return { x, z };
 }
 
+function pointInPolygon(x, z, polygon) {
+  if (!Array.isArray(polygon) || polygon.length < 3) return true;
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x;
+    const zi = polygon[i].z;
+    const xj = polygon[j].x;
+    const zj = polygon[j].z;
+    const intersect = ((zi > z) !== (zj > z)) && (x < (xj - xi) * (z - zi) / (zj - zi + 1e-9) + xi);
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+function segmentWithinPolygon(segment, polygon) {
+  if (!Array.isArray(polygon) || polygon.length < 3) return true;
+  const midX = (segment.start.x + segment.end.x) / 2;
+  const midZ = (segment.start.z + segment.end.z) / 2;
+  return pointInPolygon(midX, midZ, polygon);
+}
+
 function dist2(x1, z1, x2, z2) {
   const dx = x2 - x1;
   const dz = z2 - z1;
@@ -74,7 +95,7 @@ function pickRandom(items) {
   return items[Math.floor(Math.random() * items.length)];
 }
 
-function buildRoadNetwork(roads, minWidth = 3) {
+function buildRoadNetwork(roads, minWidth = 3, restrictPolygon = null) {
   const segments = [];
   const nodes = new Map();
   const addNode = (key, point, segment, dir) => {
@@ -102,6 +123,7 @@ function buildRoadNetwork(roads, minWidth = 3) {
         endKey: makeNodeKey(end),
         length,
       };
+      if (restrictPolygon && !segmentWithinPolygon(segment, restrictPolygon)) continue;
       segments.push(segment);
       addNode(segment.startKey, start, segment, 1);
       addNode(segment.endKey, end, segment, -1);
@@ -156,6 +178,41 @@ function handleArrival(ai, npcGroup) {
   }
 
   const arrivedKey = ai.travelDir > 0 ? ai.currentSegment.endKey : ai.currentSegment.startKey;
+  if (ai.loopConfig) {
+    const loopState = ai.loopState || (ai.loopState = {
+      originKey: ai.loopConfig.anchorKey || null,
+      stepsSinceOrigin: 0,
+      hasLeftOrigin: false,
+      loopCount: 0,
+    });
+    if (!loopState.originKey) {
+      loopState.originKey = ai.loopConfig.anchorKey || arrivedKey;
+      loopState.stepsSinceOrigin = 0;
+      loopState.hasLeftOrigin = false;
+    } else {
+      loopState.stepsSinceOrigin += 1;
+      if (arrivedKey === loopState.originKey) {
+        if (loopState.hasLeftOrigin && loopState.stepsSinceOrigin >= ai.loopConfig.minSegments) {
+          loopState.loopCount += 1;
+          loopState.stepsSinceOrigin = 0;
+          loopState.hasLeftOrigin = false;
+          if (ai.loopConfig.onComplete) {
+            try {
+              ai.loopConfig.onComplete(loopState.loopCount, npcGroup, ai);
+            } catch (_) {}
+          }
+          if (ai.loopConfig.resetOriginOnComplete) {
+            loopState.originKey = ai.loopConfig.anchorKey || arrivedKey;
+          }
+        } else {
+          loopState.stepsSinceOrigin = 0;
+          loopState.hasLeftOrigin = false;
+        }
+      } else {
+        loopState.hasLeftOrigin = true;
+      }
+    }
+  }
   const next = chooseNextSegment(ai, arrivedKey);
   if (!next) {
     ai.travelDir *= -1;
@@ -177,6 +234,18 @@ export function attachRoadPatrol(npcGroup, options = {}) {
   const pauseChance = Math.max(0, Math.min(1, options.pauseChance ?? 0.35));
   const radius = Math.max(1.2, Math.min(3.0, options.radius || (npcGroup.userData?.collider?.radius ?? 2.0)));
   const fallback = typeof options.onError === 'function' ? options.onError : null;
+  const restrictPolygon = Array.isArray(options.restrictToPolygon) && options.restrictToPolygon.length >= 3
+    ? options.restrictToPolygon
+    : null;
+  const loopCfgRaw = options.loop && typeof options.loop === 'object' ? options.loop : null;
+  const loopConfig = loopCfgRaw
+    ? {
+        minSegments: Math.max(1, loopCfgRaw.minSegments || 4),
+        onComplete: typeof loopCfgRaw.onComplete === 'function' ? loopCfgRaw.onComplete : null,
+        anchorKey: typeof loopCfgRaw.anchorKey === 'string' && loopCfgRaw.anchorKey.length ? loopCfgRaw.anchorKey : null,
+        resetOriginOnComplete: loopCfgRaw.resetOriginOnComplete !== false,
+      }
+    : null;
 
   npcGroup.userData.ai = {
     type: 'roadPatrol',
@@ -194,11 +263,13 @@ export function attachRoadPatrol(npcGroup, options = {}) {
     segments: [],
     nodes: new Map(),
     ready: false,
+    loopConfig,
+    loopState: loopConfig ? { originKey: loopConfig.anchorKey || null, stepsSinceOrigin: 0, hasLeftOrigin: false, loopCount: 0 } : null,
   };
 
   loadKonohaRoads()
     .then(({ roads }) => {
-      const { segments, nodes } = buildRoadNetwork(roads?.all || [], options.minRoadWidth || 3);
+      const { segments, nodes } = buildRoadNetwork(roads?.all || [], options.minRoadWidth || 3, restrictPolygon);
       if (!segments.length) {
         if (fallback) fallback();
         return;

--- a/src/game/npcs/naruto.js
+++ b/src/game/npcs/naruto.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import { createNpcRig } from './common.js';
-import { attachWanderFree } from './behaviors/wanderFree.js';
-import { attachRoadPatrol } from './behaviors/roadPatrol.js';
+import { attachNarutoRoutine } from './behaviors/narutoRoutine.js';
 import { getPlayerIdentity } from '../player/identity.js';
 
 export function createNaruto(scene, settings, position = new THREE.Vector3()) {
@@ -42,18 +41,9 @@ export function createNaruto(scene, settings, position = new THREE.Vector3()) {
         } catch (_) {}
       };
     } catch (_) {}
-    // Give Naruto a road-focused patrol; fall back to free wander if unavailable
     try {
-      attachRoadPatrol(group, {
-        speed: 8,
-        pauseChance: 0.25,
-        onError: () => {
-          try { attachWanderFree(group, { speed: 8 }); } catch (_) {}
-        }
-      });
-    } catch (_) {
-      try { attachWanderFree(group, { speed: 8 }); } catch (_) {}
-    }
+      attachNarutoRoutine(group, { spawnPosition: group.position.clone() });
+    } catch (_) {}
     return group;
   });
 }

--- a/src/game/npcs/shikamaru.js
+++ b/src/game/npcs/shikamaru.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { createNpcRig } from './common.js';
 import { attachWanderFree } from './behaviors/wanderFree.js';
+import { attachRoadPatrol } from './behaviors/roadPatrol.js';
 import { getPlayerIdentity } from '../player/identity.js';
 import { loadKonohaRoads } from '/src/components/game/objects/konoha_roads.js';
 import { WORLD_SIZE } from '/src/scene/terrain.js';
@@ -59,22 +60,38 @@ export function createShikamaru(scene, settings, position = new THREE.Vector3())
         } catch (_) {}
       };
     } catch (_) {}
-    const applyWander = (polygon) => {
-      const options = { speed: 8 };
-      if (polygon) {
-        options.keepWithinPolygon = polygon;
+    const applyRoam = (polygon) => {
+      const fallbackWander = () => {
+        const options = { speed: 8 };
+        if (polygon) {
+          options.keepWithinPolygon = polygon;
+        }
+        try { attachWanderFree(group, options); } catch (_) {}
+      };
+
+      try {
+        attachRoadPatrol(group, {
+          speed: 7,
+          pauseChance: 0.5,
+          pauseMin: 1.8,
+          pauseMax: 4.5,
+          minRoadWidth: 2.5,
+          restrictToPolygon: polygon,
+          onError: fallbackWander,
+        });
+      } catch (_) {
+        fallbackWander();
       }
-      try { attachWanderFree(group, options); } catch (_) {}
     };
 
     loadKonohaRoads()
       .then(({ districts }) => {
         const district = districts?.Nara || districts?.nara;
         const polygon = districtPolygonToWorld(district?.points);
-        applyWander(polygon);
+        applyRoam(polygon);
       })
       .catch(() => {
-        applyWander(null);
+        applyRoam(null);
       });
     return group;
   });

--- a/src/scene/animationLoop.js
+++ b/src/scene/animationLoop.js
@@ -2,6 +2,7 @@ import * as TWEEN from '@tweenjs/tween.js';
 import { updatePlayer } from '../game/player/index.js';
 import { updateWanderFree } from '/src/game/npcs/behaviors/wanderFree.js';
 import { updateRoadPatrol } from '/src/game/npcs/behaviors/roadPatrol.js';
+import { updateNarutoRoutine } from '/src/game/npcs/behaviors/narutoRoutine.js';
 import { INTERACTION_DISTANCE } from '../game/constants.js';
 import { multiplayerManager } from '../network/multiplayerManager.js';
 
@@ -316,9 +317,10 @@ export function startAnimationLoop({
                             }
                         }
                     } catch (_) {}
-                    // Per-NPC behavior (free wander attached to Shikamaru only)
+                    // Per-NPC behavior hooks
                     try { updateWanderFree(g, delta, objectGridRef.current); } catch (_) {}
                     try { updateRoadPatrol(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateNarutoRoutine(g, delta, objectGridRef.current); } catch (_) {}
                     // Ensure mixer advances regardless
                     try { g?.userData?.mixer?.update(delta); } catch (_) {}
                 }


### PR DESCRIPTION
## Summary
- orchestrate Naruto's alternating patrol and loiter routine with a dedicated behavior controller
- extend the shared road patrol AI to support polygon filtering and loop callbacks, then reuse it for Shikamaru's district roaming
- wire animation loop updates so Naruto's routine and Shikamaru's road focus stay active across the scene

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e00e01bf988332a0fd0ebddc134872