### PR TITLE
Improve Naruto and Shikamaru patrol roaming

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,5 @@
 Recent
+- NPC Patrols: Naruto and Shikamaru now stroll their roads, wander off-route for moments, and return within half a minute.
 - Tests: Added useWorldEvents hook coverage for countdown overlays, buffs, overrides, and dismiss flows.
 - Tests: Added time utility formatting and useGameTime hook coverage with fake timers and pause handling.
 - FPV/NPC Dialog: Keep first-person active during conversations by suspending controls and restoring pointer lock on close.

--- a/src/game/npcs/behaviors/narutoRoutine.js
+++ b/src/game/npcs/behaviors/narutoRoutine.js
@@ -3,16 +3,16 @@ import { resolveCollisions } from '/src/game/player/movement/collision.js';
 import { attachRoadPatrol } from './roadPatrol.js';
 import { attachWanderFree } from './wanderFree.js';
 
-const WALK_PATROL_SPEED = 8;
-const RUN_PATROL_SPEED = 13;
-const RETURN_WALK_SPEED = 8.5;
-const RETURN_RUN_SPEED = 11.5;
+const WALK_PATROL_SPEED = 5.75;
+const RUN_PATROL_SPEED = 8.75;
+const RETURN_WALK_SPEED = 6.5;
+const RETURN_RUN_SPEED = 9.5;
 const RETURN_TOLERANCE = 1.75;
-const WANDER_SPEED = 6.5;
-const WANDER_DURATION_MIN = 30;
-const WANDER_DURATION_MAX = 70;
-const WANDER_RADIUS = 18;
-const WANDER_CENTER_JITTER = 8;
+const WANDER_SPEED = 5.25;
+const WANDER_DURATION_MIN = 2;
+const WANDER_DURATION_MAX = 30;
+const WANDER_RADIUS = 20;
+const WANDER_CENTER_JITTER = 10;
 const MODE_POOL = ['walk', 'run'];
 
 function shuffle(array) {
@@ -112,11 +112,11 @@ function startWander(npcGroup, routine, overrideDuration = null) {
   try {
     attachWanderFree(npcGroup, {
       speed: WANDER_SPEED,
-      pauseChance: 0.65,
-      pauseMin: 1.5,
-      pauseMax: 4.5,
-      dirChangeMin: 2.5,
-      dirChangeMax: 5.5,
+      pauseChance: 0.7,
+      pauseMin: 0.8,
+      pauseMax: 3.8,
+      dirChangeMin: 1.8,
+      dirChangeMax: 4.2,
       keepWithinPolygon: polygon,
     });
   } catch (_) {
@@ -136,9 +136,10 @@ function startPatrol(npcGroup, routine, mode) {
   const pauseMin = mode === 'run' ? 0.5 : 1.5;
   const pauseMax = mode === 'run' ? 1.6 : 4.2;
   const minSegments = mode === 'run' ? 8 : 6;
+  const deviationRadius = Math.max(8, routine.wanderRadius * (mode === 'run' ? 0.65 : 0.8));
 
   const fallbackToWander = () => {
-    startWander(npcGroup, routine, 40);
+    startWander(npcGroup, routine, 18);
   };
 
   try {
@@ -154,6 +155,17 @@ function startPatrol(npcGroup, routine, mode) {
             routine.loopTriggered = true;
           }
         },
+      },
+      deviation: {
+        chance: mode === 'run' ? 0.25 : 0.4,
+        radius: deviationRadius,
+        speed: mode === 'run' ? Math.max(5.5, speed * 0.85) : Math.max(4.2, speed * 0.95),
+        durationMin: 2,
+        durationMax: mode === 'run' ? 18 : 26,
+        pauseChance: mode === 'run' ? 0.35 : 0.5,
+        pauseMin: 0.7,
+        pauseMax: mode === 'run' ? 2.4 : 3.6,
+        radiusCollision: npcGroup.userData?.collider?.radius ?? 2.0,
       },
       onError: fallbackToWander,
     });

--- a/src/game/npcs/behaviors/roadPatrol.js
+++ b/src/game/npcs/behaviors/roadPatrol.js
@@ -61,19 +61,29 @@ function makeNodeKey(point) {
   return `${point.x.toFixed(2)},${point.z.toFixed(2)}`;
 }
 
-function ensureWalkingAnimation(npcGroup) {
+const WALK_SPEED_THRESHOLD = 7.25;
+
+function ensureMoveAnimation(npcGroup, speed = WALK_SPEED_THRESHOLD) {
   const actions = npcGroup?.userData?.animations;
   if (!actions) return;
-  const walkingAction = actions.running || actions.runFast || actions.walking || actions.casualWalk;
-  if (!walkingAction) return;
-  if (npcGroup.userData.currentAnimation === walkingAction._clip?.name) return;
-  try {
-    Object.values(actions).forEach((action) => action.stop());
-    walkingAction.reset();
-    walkingAction.setLoop(THREE.LoopRepeat);
-    walkingAction.play();
-    npcGroup.userData.currentAnimation = walkingAction._clip?.name || 'walking';
-  } catch (_) {}
+  const preferWalk = speed <= WALK_SPEED_THRESHOLD;
+  const candidates = preferWalk
+    ? ['walking', 'casualWalk', 'running', 'runFast']
+    : ['running', 'runFast', 'walking', 'casualWalk'];
+  for (const key of candidates) {
+    const action = actions[key];
+    if (!action) continue;
+    const desiredName = action._clip?.name || key;
+    if (npcGroup.userData.currentAnimation === desiredName) return;
+    try {
+      Object.values(actions).forEach((anim) => anim.stop());
+      action.reset();
+      action.setLoop(THREE.LoopRepeat);
+      action.play();
+      npcGroup.userData.currentAnimation = desiredName;
+    } catch (_) {}
+    return;
+  }
 }
 
 function ensureIdleAnimation(npcGroup) {
@@ -155,10 +165,25 @@ function chooseNextSegment(ai, currentNodeKey) {
   return pickRandom(pool);
 }
 
-function setTarget(ai, npcGroup, targetPoint) {
+function setTarget(ai, npcGroup, targetPoint, speedOverride = null) {
   if (!targetPoint) return;
   ai.targetPoint = { x: targetPoint.x, z: targetPoint.z };
-  ensureWalkingAnimation(npcGroup);
+  ensureMoveAnimation(npcGroup, speedOverride ?? ai.speed ?? WALK_SPEED_THRESHOLD);
+}
+
+function maybeStartDeviation(ai, npcGroup) {
+  if (!ai.deviation || ai.mode === 'deviate') return false;
+  if (Math.random() >= ai.deviation.chance) return false;
+  const duration = ai.deviation.durationMin + Math.random() * (ai.deviation.durationMax - ai.deviation.durationMin);
+  ai.mode = 'deviate';
+  ai.deviationState = {
+    timer: duration,
+    wait: 0,
+    origin: { x: npcGroup.position.x, z: npcGroup.position.z },
+    target: null,
+  };
+  ensureMoveAnimation(npcGroup, ai.deviation.speed);
+  return true;
 }
 
 function handleArrival(ai, npcGroup) {
@@ -166,7 +191,7 @@ function handleArrival(ai, npcGroup) {
     ai.mode = 'patrol';
     if (!ai.currentSegment) return;
     const nextPoint = ai.travelDir > 0 ? ai.currentSegment.end : ai.currentSegment.start;
-    setTarget(ai, npcGroup, nextPoint);
+    setTarget(ai, npcGroup, nextPoint, ai.speed);
     return;
   }
 
@@ -175,6 +200,11 @@ function handleArrival(ai, npcGroup) {
   if (Math.random() < pauseChance) {
     ai.wait = ai.pauseMin + Math.random() * (ai.pauseMax - ai.pauseMin);
     ensureIdleAnimation(npcGroup);
+  }
+
+  if (maybeStartDeviation(ai, npcGroup)) {
+    ai.targetPoint = null;
+    return;
   }
 
   const arrivedKey = ai.travelDir > 0 ? ai.currentSegment.endKey : ai.currentSegment.startKey;
@@ -213,18 +243,111 @@ function handleArrival(ai, npcGroup) {
       }
     }
   }
+
   const next = chooseNextSegment(ai, arrivedKey);
-  if (!next) {
-    ai.travelDir *= -1;
-    const fallbackPoint = ai.travelDir > 0 ? ai.currentSegment.end : ai.currentSegment.start;
-    setTarget(ai, npcGroup, fallbackPoint);
+    if (!next) {
+      ai.travelDir *= -1;
+      const fallbackPoint = ai.travelDir > 0 ? ai.currentSegment.end : ai.currentSegment.start;
+      setTarget(ai, npcGroup, fallbackPoint, ai.speed);
+      return;
+    }
+
+    ai.currentSegment = next.segment;
+    ai.travelDir = next.dir;
+    const destination = ai.travelDir > 0 ? ai.currentSegment.end : ai.currentSegment.start;
+    setTarget(ai, npcGroup, destination, ai.speed);
+}
+
+function randomPointInRadius(origin, radius) {
+  const angle = Math.random() * Math.PI * 2;
+  const distance = Math.sqrt(Math.random()) * radius;
+  return {
+    x: origin.x + Math.cos(angle) * distance,
+    z: origin.z + Math.sin(angle) * distance,
+  };
+}
+
+function finishDeviation(ai, npcGroup) {
+  ai.mode = 'approach';
+  ai.deviationState = null;
+  const nearest = nearestSegment(npcGroup.position, ai.segments);
+  if (!nearest) {
+    ai.targetPoint = null;
+    ai.mode = 'patrol';
+    return;
+  }
+  ai.currentSegment = nearest.segment;
+  const distToStart = dist2(npcGroup.position.x, npcGroup.position.z, nearest.segment.start.x, nearest.segment.start.z);
+  const distToEnd = dist2(npcGroup.position.x, npcGroup.position.z, nearest.segment.end.x, nearest.segment.end.z);
+  ai.travelDir = distToEnd < distToStart ? 1 : -1;
+  ai.pendingTarget = ai.travelDir > 0 ? nearest.segment.end : nearest.segment.start;
+  setTarget(ai, npcGroup, nearest.projection.point, ai.speed);
+}
+
+function updateDeviation(ai, npcGroup, delta, objectGrid) {
+  const deviation = ai.deviation;
+  const state = ai.deviationState;
+  if (!deviation || !state) {
+    finishDeviation(ai, npcGroup);
     return;
   }
 
-  ai.currentSegment = next.segment;
-  ai.travelDir = next.dir;
-  const destination = ai.travelDir > 0 ? ai.currentSegment.end : ai.currentSegment.start;
-  setTarget(ai, npcGroup, destination);
+  state.timer -= delta;
+  if (state.timer <= 0) {
+    finishDeviation(ai, npcGroup);
+    return;
+  }
+
+  if (state.wait > 0) {
+    state.wait -= delta;
+    if (state.wait <= 0) {
+      state.wait = 0;
+      ensureMoveAnimation(npcGroup, deviation.speed);
+    } else {
+      return;
+    }
+  }
+
+  if (!state.target) {
+    if (Math.random() < deviation.pauseChance) {
+      state.wait = deviation.pauseMin + Math.random() * (deviation.pauseMax - deviation.pauseMin);
+      ensureIdleAnimation(npcGroup);
+      return;
+    }
+    state.target = randomPointInRadius(state.origin, deviation.radius);
+    ensureMoveAnimation(npcGroup, deviation.speed);
+  }
+
+  const dx = state.target.x - npcGroup.position.x;
+  const dz = state.target.z - npcGroup.position.z;
+  const distance = Math.hypot(dx, dz);
+  if (distance < 0.1) {
+    state.target = null;
+    return;
+  }
+
+  const step = deviation.speed * delta;
+  const prevX = npcGroup.position.x;
+  const prevZ = npcGroup.position.z;
+  const moveX = prevX + (dx / (distance || 1)) * Math.min(step, distance);
+  const moveZ = prevZ + (dz / (distance || 1)) * Math.min(step, distance);
+  const intended = { x: moveX, z: moveZ };
+  const restoreFlag = npcGroup.userData.__ignoreCollision;
+  npcGroup.userData.__ignoreCollision = true;
+  const collisionRadius = deviation.radiusCollision ?? ai.radius;
+  const resolved = resolveCollisions(intended, collisionRadius, objectGrid);
+  npcGroup.userData.__ignoreCollision = restoreFlag;
+  npcGroup.position.x = resolved.x;
+  npcGroup.position.z = resolved.z;
+
+  try {
+    const model = npcGroup.userData.model || npcGroup.children?.[0];
+    const moveDirX = npcGroup.position.x - prevX;
+    const moveDirZ = npcGroup.position.z - prevZ;
+    if (model && (Math.abs(moveDirX) > 1e-3 || Math.abs(moveDirZ) > 1e-3)) {
+      model.rotation.y = Math.atan2(moveDirX, moveDirZ);
+    }
+  } catch (_) {}
 }
 
 export function attachRoadPatrol(npcGroup, options = {}) {
@@ -247,6 +370,24 @@ export function attachRoadPatrol(npcGroup, options = {}) {
       }
     : null;
 
+  const deviationRaw = options.deviation && typeof options.deviation === 'object' ? options.deviation : null;
+  const deviation = deviationRaw
+    ? {
+        chance: Math.max(0, Math.min(1, deviationRaw.chance ?? 0.3)),
+        radius: Math.max(2, deviationRaw.radius ?? 10),
+        speed: Math.max(2, Math.min(20, deviationRaw.speed ?? Math.max(2, speed * 0.85))),
+        durationMin: Math.max(0.5, deviationRaw.durationMin ?? 4),
+        durationMax: Math.max(
+          Math.max(0.5, deviationRaw.durationMin ?? 4),
+          deviationRaw.durationMax ?? 12,
+        ),
+        pauseChance: Math.max(0, Math.min(1, deviationRaw.pauseChance ?? pauseChance)),
+        pauseMin: Math.max(0, deviationRaw.pauseMin ?? pauseMin),
+        pauseMax: Math.max(deviationRaw.pauseMin ?? pauseMin, deviationRaw.pauseMax ?? pauseMax),
+        radiusCollision: Math.max(1.2, Math.min(3.0, deviationRaw.radiusCollision || radius)),
+      }
+    : null;
+
   npcGroup.userData.ai = {
     type: 'roadPatrol',
     speed,
@@ -265,6 +406,8 @@ export function attachRoadPatrol(npcGroup, options = {}) {
     ready: false,
     loopConfig,
     loopState: loopConfig ? { originKey: loopConfig.anchorKey || null, stepsSinceOrigin: 0, hasLeftOrigin: false, loopCount: 0 } : null,
+    deviation,
+    deviationState: null,
   };
 
   loadKonohaRoads()
@@ -285,7 +428,7 @@ export function attachRoadPatrol(npcGroup, options = {}) {
         ai.mode = 'approach';
         ai.travelDir = Math.random() < 0.5 ? 1 : -1;
         ai.pendingTarget = ai.travelDir > 0 ? nearest.segment.end : nearest.segment.start;
-        setTarget(ai, npcGroup, nearest.projection.point);
+        setTarget(ai, npcGroup, nearest.projection.point, ai.speed);
       }
     })
     .catch(() => {
@@ -301,9 +444,19 @@ export function updateRoadPatrol(npcGroup, delta, objectGrid) {
     ai.wait -= delta;
     if (ai.wait <= 0) {
       ai.wait = 0;
-      ensureWalkingAnimation(npcGroup);
+      ensureMoveAnimation(npcGroup, ai.mode === 'deviate' && ai.deviation ? ai.deviation.speed : ai.speed);
     }
     return;
+  }
+
+  if (ai.mode === 'deviate') {
+    updateDeviation(ai, npcGroup, delta, objectGrid);
+    if (ai.mode === 'deviate') {
+      return;
+    }
+    if (ai.mode === 'approach') {
+      ai.targetPoint = ai.targetPoint || null;
+    }
   }
 
   if (!ai.ready || !ai.currentSegment) return;
@@ -317,7 +470,7 @@ export function updateRoadPatrol(npcGroup, delta, objectGrid) {
   const distance = Math.hypot(dx, dz);
   if (distance < 0.05) {
     if (ai.mode === 'approach' && ai.pendingTarget) {
-      setTarget(ai, npcGroup, ai.pendingTarget);
+      setTarget(ai, npcGroup, ai.pendingTarget, ai.speed);
       ai.mode = 'patrol';
       ai.pendingTarget = null;
       return;
@@ -326,7 +479,8 @@ export function updateRoadPatrol(npcGroup, delta, objectGrid) {
     return;
   }
 
-  const step = ai.speed * delta;
+  const moveSpeed = ai.speed;
+  const step = moveSpeed * delta;
   const normX = dx / (distance || 1);
   const normZ = dz / (distance || 1);
   const moveX = npcGroup.position.x + normX * Math.min(step, distance);
@@ -348,14 +502,14 @@ export function updateRoadPatrol(npcGroup, delta, objectGrid) {
     }
   } catch (_) {}
 
-  if (Math.hypot(ai.targetPoint.x - npcGroup.position.x, ai.targetPoint.z - npcGroup.position.z) < 0.3) {
-    if (ai.mode === 'approach' && ai.pendingTarget) {
-      setTarget(ai, npcGroup, ai.pendingTarget);
-      ai.mode = 'patrol';
-      ai.pendingTarget = null;
-    } else {
-      handleArrival(ai, npcGroup);
+    if (Math.hypot(ai.targetPoint.x - npcGroup.position.x, ai.targetPoint.z - npcGroup.position.z) < 0.3) {
+      if (ai.mode === 'approach' && ai.pendingTarget) {
+        setTarget(ai, npcGroup, ai.pendingTarget, ai.speed);
+        ai.mode = 'patrol';
+        ai.pendingTarget = null;
+      } else {
+        handleArrival(ai, npcGroup);
+      }
     }
-  }
 }
 

--- a/src/game/npcs/shikamaru.js
+++ b/src/game/npcs/shikamaru.js
@@ -62,7 +62,7 @@ export function createShikamaru(scene, settings, position = new THREE.Vector3())
     } catch (_) {}
     const applyRoam = (polygon) => {
       const fallbackWander = () => {
-        const options = { speed: 8 };
+        const options = { speed: 5.5 };
         if (polygon) {
           options.keepWithinPolygon = polygon;
         }
@@ -71,12 +71,23 @@ export function createShikamaru(scene, settings, position = new THREE.Vector3())
 
       try {
         attachRoadPatrol(group, {
-          speed: 7,
-          pauseChance: 0.5,
-          pauseMin: 1.8,
-          pauseMax: 4.5,
+          speed: 5.6,
+          pauseChance: 0.55,
+          pauseMin: 1.2,
+          pauseMax: 3.8,
           minRoadWidth: 2.5,
           restrictToPolygon: polygon,
+          deviation: {
+            chance: 0.45,
+            radius: polygon ? 14 : 18,
+            speed: 5,
+            durationMin: 2,
+            durationMax: 22,
+            pauseChance: 0.55,
+            pauseMin: 0.9,
+            pauseMax: 3.2,
+            radiusCollision: group.userData?.collider?.radius ?? 2.0,
+          },
           onError: fallbackWander,
         });
       } catch (_) {


### PR DESCRIPTION
## Summary
- slow Naruto's patrol speeds, expand his wander radius, and limit off-route breaks to 2-30 seconds
- extend the shared road patrol AI with walking-aware animations and short deviation loops before rejoining the road
- retune Shikamaru's patrol pacing to use the new deviation logic with gentler speeds and a wander fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0120a1f888332a54ac6a7ab793626