### PR TITLE
Add dynamic sky environment tied to day-night cycle

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -54,3 +54,4 @@ Recent
 - NPCs: Naruto now patrols Konoha roads from MO382 and Shikamaru roams the Nara District after spawning at RJ416.
 - NPCs: Naruto alternates full road loops with ramen-side loitering, swapping between walk and run patrols after each wander.
 - NPCs: Shikamaru now follows the Nara district road grid with fallbacks to free roaming so he explores instead of pacing.
+- World: Added a gradient skysphere plus sun and moon sprites that follow the dynamic day-night cycle.

--- a/src/scene/animationLoop.js
+++ b/src/scene/animationLoop.js
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import * as TWEEN from '@tweenjs/tween.js';
 import { updatePlayer } from '../game/player/index.js';
 import { updateWanderFree } from '/src/game/npcs/behaviors/wanderFree.js';
@@ -46,6 +47,8 @@ export function startAnimationLoop({
     };
     const fpsInterval = fpsIntervals[fpsLimit] || 0;
     let lastFrameTime = 0;
+    const tmpSunVec = new THREE.Vector3();
+    const tmpMoonVec = new THREE.Vector3();
 
     const interactionDistance = INTERACTION_DISTANCE; // world units to interact
     let lastInteractObj = null;
@@ -404,6 +407,40 @@ export function startAnimationLoop({
             multiplayerManager.update(delta, timestamp);
         } catch (err) {
             console.error('[Multiplayer] update() failed:', err);
+        }
+
+        const scene = sceneRef.current;
+        const camera = cameraRef.current;
+        if (scene && camera) {
+            const sky = scene.userData?.sky;
+            const light = lightRef.current;
+            if (sky) {
+                if (sky.skyDome) {
+                    sky.skyDome.position.copy(camera.position);
+                }
+                const sunDir = light?.userData?.sunDirection;
+                const moonDir = light?.userData?.moonDirection;
+                if (sky.sun) {
+                    const distance = sky.sun.userData?.distance || 3000;
+                    if (sunDir?.isVector3 && sunDir.lengthSq() > 1e-6) {
+                        tmpSunVec.copy(sunDir).normalize();
+                    } else {
+                        tmpSunVec.set(0.25, 0.8, 0.3).normalize();
+                    }
+                    sky.sun.position.copy(camera.position).addScaledVector(tmpSunVec, distance);
+                }
+                if (sky.moon) {
+                    const distance = sky.moon.userData?.distance || 2600;
+                    if (moonDir?.isVector3 && moonDir.lengthSq() > 1e-6) {
+                        tmpMoonVec.copy(moonDir).normalize();
+                    } else if (sunDir?.isVector3 && sunDir.lengthSq() > 1e-6) {
+                        tmpMoonVec.copy(sunDir).multiplyScalar(-1).normalize();
+                    } else {
+                        tmpMoonVec.set(-0.25, 0.6, -0.3).normalize();
+                    }
+                    sky.moon.position.copy(camera.position).addScaledVector(tmpMoonVec, distance);
+                }
+            }
         }
 
         rendererRef.current.render(sceneRef.current, cameraRef.current);

--- a/src/scene/dayNightCycle.js
+++ b/src/scene/dayNightCycle.js
@@ -10,6 +10,13 @@ const sunsetSunColor = new THREE.Color(0xffc98a);
 const dayAmbientColor = new THREE.Color(0xfefefe);
 const nightAmbientColor = new THREE.Color(0x111a26);
 const warmAmbientColor = new THREE.Color(0xffd9a3);
+const daySkyTopColor = new THREE.Color('#7cc4ff');
+const daySkyBottomColor = new THREE.Color('#cde9ff');
+const duskSkyTopColor = new THREE.Color('#ff9159');
+const duskSkyBottomColor = new THREE.Color('#ffd6a6');
+const nightSkyTopColor = new THREE.Color('#07112c');
+const nightSkyBottomColor = new THREE.Color('#030a17');
+const moonGlowColor = new THREE.Color('#f4f6ff');
 
 const tmpSunColor = new THREE.Color();
 const tmpAmbientColor = new THREE.Color();
@@ -18,6 +25,14 @@ const tmpFogColor = new THREE.Color();
 const tmpOffset = new THREE.Vector3();
 const tmpWindowColor = new THREE.Color();
 const tmpWindowEmissive = new THREE.Color();
+const tmpSkyTop = new THREE.Color();
+const tmpSkyBottom = new THREE.Color();
+const tmpNightTop = new THREE.Color();
+const tmpNightBottom = new THREE.Color();
+const tmpSunGlow = new THREE.Color();
+const tmpMoonColor = new THREE.Color();
+const tmpSunDirection = new THREE.Vector3();
+const tmpMoonDirection = new THREE.Vector3();
 
 const KITBASH_DAY_START = 6;
 const KITBASH_EVENING_START = 18;
@@ -45,7 +60,7 @@ export function applyDayNightCycle({ scene, directionalLight, ambientLight, time
   const daylightBlend = clamp01(smoothstep(6, 7, hour) - smoothstep(19, 20, hour));
   const twilightBlend = clamp01(smoothstep(5, 6, hour) + (1 - smoothstep(20, 21, hour)));
   const brightnessFloor = 0.12;
-  const brightness = brightnessFloor + daylightBlend * (1 - brightnessFloor);
+  const nightBlend = 1 - daylightBlend;
 
   const sunriseWarm = clamp01(1 - Math.abs(hour - 6) / 2);
   const sunsetWarm = clamp01(1 - Math.abs(hour - 18) / 2);
@@ -72,6 +87,44 @@ export function applyDayNightCycle({ scene, directionalLight, ambientLight, time
       tmpSkyColor.lerp(sunsetSunColor, combinedWarm * 0.2);
     }
     scene.background.copy(tmpSkyColor);
+  }
+
+  const sky = directionalLight.userData?.sky;
+  if (sky) {
+    const { uniforms, sun, moon } = sky;
+    if (uniforms) {
+      tmpSkyTop.copy(daySkyTopColor).lerp(duskSkyTopColor, combinedWarm * 0.7);
+      tmpSkyBottom.copy(daySkyBottomColor).lerp(duskSkyBottomColor, combinedWarm * 0.9);
+      tmpNightTop.copy(nightSkyTopColor);
+      tmpNightBottom.copy(nightSkyBottomColor);
+
+      uniforms.topColor.value.copy(tmpSkyTop);
+      uniforms.bottomColor.value.copy(tmpSkyBottom);
+      uniforms.nightTopColor.value.copy(tmpNightTop);
+      uniforms.nightBottomColor.value.copy(tmpNightBottom);
+      uniforms.horizonBlend.value = clamp01(0.1 + daylightBlend * 0.9);
+      uniforms.duskFactor.value = clamp01(combinedWarm * 0.8 + twilightBlend * 0.4);
+      const starIntensity = clamp01(Math.pow(nightBlend, 1.4) + Math.max(0, twilightBlend - 0.3) * 0.5);
+      uniforms.starIntensity.value = starIntensity;
+    }
+
+    if (sun?.material) {
+      const opacity = clamp01(0.15 + daylightBlend * 0.9 + combinedWarm * 0.3);
+      sun.material.opacity = opacity;
+      sun.visible = opacity > 0.02;
+      if (sun.material.color) {
+        sun.material.color.copy(tmpSunGlow.copy(daySunColor).lerp(sunsetSunColor, combinedWarm));
+      }
+    }
+
+    if (moon?.material) {
+      const moonStrength = clamp01(Math.pow(nightBlend, 1.2) + Math.max(0, twilightBlend - 0.4) * 0.2);
+      moon.material.opacity = 0.1 + moonStrength * 0.9;
+      moon.visible = moon.material.opacity > 0.05;
+      if (moon.material.color) {
+        moon.material.color.copy(tmpMoonColor.copy(moonGlowColor).lerp(nightSunColor, 0.25));
+      }
+    }
   }
 
   if (scene?.fog?.color && scene.fog.color.isColor) {
@@ -105,6 +158,25 @@ export function applyDayNightCycle({ scene, directionalLight, ambientLight, time
     } else {
       directionalLight.userData.sunOffset.copy(tmpOffset);
     }
+
+    const sunDir = tmpSunDirection.copy(tmpOffset).normalize();
+    if (!directionalLight.userData.sunDirection || !directionalLight.userData.sunDirection.isVector3) {
+      directionalLight.userData.sunDirection = sunDir.clone();
+    } else {
+      directionalLight.userData.sunDirection.copy(sunDir);
+    }
+
+    const moonDir = tmpMoonDirection.copy(sunDir).multiplyScalar(-1);
+    if (!directionalLight.userData.moonDirection || !directionalLight.userData.moonDirection.isVector3) {
+      directionalLight.userData.moonDirection = moonDir.clone();
+    } else {
+      directionalLight.userData.moonDirection.copy(moonDir);
+    }
+
+    directionalLight.userData.daylightBlend = daylightBlend;
+    directionalLight.userData.twilightBlend = twilightBlend;
+    directionalLight.userData.nightBlend = nightBlend;
+    directionalLight.userData.sunWarmth = combinedWarm;
   }
 }
 

--- a/src/scene/initScene.js
+++ b/src/scene/initScene.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { createTerrain } from './terrain.js';
 import { setupGridLabels } from './gridLabels.js';
 import { setupObjectTooltips } from './objectTooltips.js';
+import { createSkyEnvironment } from './skyEnvironment.js';
 import { INTERACTION_DISTANCE } from '../game/constants.js';
 
 /**
@@ -54,6 +55,13 @@ export function initScene({ mountEl, settings, createPlayer, onReady }) {
     scene.add(directionalLight);
     directionalLight.target.position.set(0, 0, 0);
     scene.add(directionalLight.target);
+
+    const sky = createSkyEnvironment();
+    scene.add(sky.skyDome);
+    scene.add(sky.sun);
+    scene.add(sky.moon);
+    scene.userData.sky = sky;
+    directionalLight.userData.sky = sky;
 
     // Terrain
     const { groundContainer, worldSize } = createTerrain(scene, settings);

--- a/src/scene/skyEnvironment.js
+++ b/src/scene/skyEnvironment.js
@@ -1,0 +1,129 @@
+import * as THREE from 'three';
+
+const SKY_RADIUS = 5000;
+const SUN_DISTANCE = 3000;
+const MOON_DISTANCE = 2800;
+
+function createRadialTexture({ innerColor, outerColor, size = 256, alpha = true }) {
+  if (typeof document === 'undefined') {
+    const data = new Uint8Array([255, 255, 255, 255]);
+    const texture = new THREE.DataTexture(data, 1, 1, THREE.RGBAFormat);
+    texture.needsUpdate = true;
+    texture.anisotropy = 1;
+    return texture;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  gradient.addColorStop(0, innerColor);
+  gradient.addColorStop(1, alpha ? `${outerColor}00` : outerColor);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.anisotropy = 4;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+export function createSkyEnvironment() {
+  const uniforms = {
+    topColor: { value: new THREE.Color('#74b6ff') },
+    bottomColor: { value: new THREE.Color('#88c9ff') },
+    nightTopColor: { value: new THREE.Color('#08163a') },
+    nightBottomColor: { value: new THREE.Color('#0a2348') },
+    horizonBlend: { value: 0.0 },
+    duskFactor: { value: 0.0 },
+    starIntensity: { value: 0.0 },
+  };
+
+  const skyGeometry = new THREE.SphereGeometry(SKY_RADIUS, 64, 32);
+  const skyMaterial = new THREE.ShaderMaterial({
+    uniforms,
+    vertexShader: `
+      varying vec3 vWorldPosition;
+      void main() {
+        vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+        vWorldPosition = worldPosition.xyz;
+        gl_Position = projectionMatrix * viewMatrix * worldPosition;
+      }
+    `,
+    fragmentShader: `
+      varying vec3 vWorldPosition;
+      uniform vec3 topColor;
+      uniform vec3 bottomColor;
+      uniform vec3 nightTopColor;
+      uniform vec3 nightBottomColor;
+      uniform float horizonBlend;
+      uniform float duskFactor;
+      uniform float starIntensity;
+
+      float rand(vec2 co){
+        return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+      }
+
+      void main() {
+        vec3 direction = normalize(vWorldPosition - cameraPosition);
+        float h = clamp(direction.y * 0.5 + 0.5, 0.0, 1.0);
+
+        vec3 dayGradient = mix(bottomColor, topColor, pow(h, 1.6));
+        vec3 nightGradient = mix(nightBottomColor, nightTopColor, pow(h, 2.5));
+        vec3 baseColor = mix(nightGradient, dayGradient, horizonBlend);
+
+        // Warm dusk tint near horizon
+        float horizon = smoothstep(0.0, 0.45, h);
+        vec3 duskColor = mix(vec3(1.0, 0.58, 0.28), vec3(0.8, 0.35, 0.5), h);
+        baseColor = mix(baseColor, duskColor, duskFactor * (1.0 - horizon));
+
+        // Procedural stars
+        float starNoise = rand(direction.xz * 100.0) * rand(direction.yx * 120.0);
+        float stars = smoothstep(0.995, 1.0, starNoise);
+        vec3 starColor = vec3(1.0) * stars * starIntensity;
+
+        gl_FragColor = vec4(baseColor + starColor, 1.0);
+      }
+    `,
+    side: THREE.BackSide,
+    depthWrite: false,
+    fog: false,
+  });
+  skyMaterial.toneMapped = false;
+
+  const skyDome = new THREE.Mesh(skyGeometry, skyMaterial);
+  skyDome.name = 'SkyDome';
+  skyDome.frustumCulled = false;
+
+  const sunTexture = createRadialTexture({ innerColor: '#fff7c8', outerColor: '#ffcf33', size: 256 });
+  const sunMaterial = new THREE.SpriteMaterial({
+    map: sunTexture,
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+    toneMapped: false,
+  });
+  const sunSprite = new THREE.Sprite(sunMaterial);
+  sunSprite.scale.setScalar(180);
+  sunSprite.name = 'SunSprite';
+  sunSprite.userData.distance = SUN_DISTANCE;
+
+  const moonTexture = createRadialTexture({ innerColor: '#f4f7ff', outerColor: '#b6c1d9', size: 256 });
+  const moonMaterial = new THREE.SpriteMaterial({
+    map: moonTexture,
+    transparent: true,
+    depthWrite: false,
+    toneMapped: false,
+  });
+  const moonSprite = new THREE.Sprite(moonMaterial);
+  moonSprite.scale.setScalar(140);
+  moonSprite.name = 'MoonSprite';
+  moonSprite.userData.distance = MOON_DISTANCE;
+
+  return {
+    skyDome,
+    sun: sunSprite,
+    moon: moonSprite,
+    uniforms,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shader-driven sky dome plus sun and moon sprites when initializing the scene
- drive sky colors and celestial visibility from the day-night cycle and keep them positioned around the camera

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0150e08948332baa8a562c1e374f8