### PR TITLE
Add NPC collision idle chat behavior

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -55,3 +55,5 @@ Recent
 - NPCs: Naruto alternates full road loops with ramen-side loitering, swapping between walk and run patrols after each wander.
 - NPCs: Shikamaru now follows the Nara district road grid with fallbacks to free roaming so he explores instead of pacing.
 - World: Added a gradient skysphere plus sun and moon sprites that follow the dynamic day-night cycle.
+
+- NPCs: Colliding characters now pause for 15s and play stand-and-chat style idles before resuming their routes.

--- a/src/game/npcs/behaviors/narutoRoutine.js
+++ b/src/game/npcs/behaviors/narutoRoutine.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
+import { ensureNpcCollisionIdle } from '../common.js';
 import { attachRoadPatrol } from './roadPatrol.js';
 import { attachWanderFree } from './wanderFree.js';
 
@@ -213,6 +214,7 @@ export function attachNarutoRoutine(npcGroup, options = {}) {
 export function updateNarutoRoutine(npcGroup, delta, objectGrid) {
   const routine = npcGroup?.userData?.__narutoRoutine;
   if (!routine) return;
+  const collisionLocked = ensureNpcCollisionIdle(npcGroup, delta, objectGrid);
   if (npcGroup.userData?.interacting) {
     playIdleAnimation(npcGroup);
     return;
@@ -226,6 +228,10 @@ export function updateNarutoRoutine(npcGroup, delta, objectGrid) {
   }
 
   if (routine.state === 'returning') {
+    if (collisionLocked) {
+      playIdleAnimation(npcGroup);
+      return;
+    }
     const ai = npcGroup.userData?.ai;
     if (!ai || ai.type !== 'narutoReturn') {
       startReturn(npcGroup, routine);

--- a/src/game/npcs/behaviors/roadPatrol.js
+++ b/src/game/npcs/behaviors/roadPatrol.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
 import { loadKonohaRoads } from '/src/components/game/objects/konoha_roads.js';
 import { WORLD_SIZE } from '/src/scene/terrain.js';
+import { ensureNpcCollisionIdle } from '../common.js';
 
 const WORLD_HALF = WORLD_SIZE / 2;
 
@@ -440,12 +441,20 @@ export function updateRoadPatrol(npcGroup, delta, objectGrid) {
   const ai = npcGroup?.userData?.ai;
   if (!ai || ai.type !== 'roadPatrol') return;
 
+  const collisionLocked = ensureNpcCollisionIdle(npcGroup, delta, objectGrid);
+
   if (ai.wait > 0) {
     ai.wait -= delta;
     if (ai.wait <= 0) {
       ai.wait = 0;
-      ensureMoveAnimation(npcGroup, ai.mode === 'deviate' && ai.deviation ? ai.deviation.speed : ai.speed);
+      if (!collisionLocked) {
+        ensureMoveAnimation(npcGroup, ai.mode === 'deviate' && ai.deviation ? ai.deviation.speed : ai.speed);
+      }
     }
+    return;
+  }
+
+  if (collisionLocked) {
     return;
   }
 

--- a/src/game/npcs/behaviors/wanderFree.js
+++ b/src/game/npcs/behaviors/wanderFree.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
+import { ensureNpcCollisionIdle } from '../common.js';
 
 function normalizePolygon(points) {
   if (!Array.isArray(points)) return null;
@@ -139,16 +140,7 @@ export function updateWanderFree(npcGroup, delta, objectGrid) {
   const ai = npcGroup?.userData?.ai;
   if (!ai || ai.type !== 'wanderFree') return;
 
-  if (ai.polygon && !pointInPolygon(npcGroup.position.x, npcGroup.position.z, ai.polygon)) {
-    const fallback = nearestPointOnPolygon(npcGroup.position.x, npcGroup.position.z, ai.polygon) || ai.polygonCentroid;
-    if (fallback) {
-      npcGroup.position.x = fallback.x;
-      npcGroup.position.z = fallback.z;
-      ai.dir = randDir();
-      ai.wait = 0.1;
-      ai.changeIn = ai.dirChangeMin || 1.5;
-    }
-  }
+  const collisionLocked = ensureNpcCollisionIdle(npcGroup, delta, objectGrid);
 
   // Reduce conversation cooldown each frame
   if (ai.convoCooldown > 0) ai.convoCooldown -= delta;
@@ -177,6 +169,25 @@ export function updateWanderFree(npcGroup, delta, objectGrid) {
       }
     } catch (_) {}
     return;
+  }
+
+  if (collisionLocked) {
+    if (ai.wait > 0) {
+      ai.wait -= delta;
+      if (ai.wait < 0) ai.wait = 0;
+    }
+    return;
+  }
+
+  if (ai.polygon && !pointInPolygon(npcGroup.position.x, npcGroup.position.z, ai.polygon)) {
+    const fallback = nearestPointOnPolygon(npcGroup.position.x, npcGroup.position.z, ai.polygon) || ai.polygonCentroid;
+    if (fallback) {
+      npcGroup.position.x = fallback.x;
+      npcGroup.position.z = fallback.z;
+      ai.dir = randDir();
+      ai.wait = 0.1;
+      ai.changeIn = ai.dirChangeMin || 1.5;
+    }
   }
 
   // Countdown timers

--- a/src/game/npcs/common.js
+++ b/src/game/npcs/common.js
@@ -204,3 +204,179 @@ export function updateNpc(group, delta) {
   if (!group || !group.userData?.mixer) return;
   try { group.userData.mixer.update(delta); } catch (_) {}
 }
+
+const COLLISION_CHAT_DURATION = 15;
+const COLLISION_CHAT_COOLDOWN = 3.5;
+const COLLISION_CHAT_SEARCH_PADDING = 2.5;
+
+function ensureCollisionState(npcGroup) {
+  if (!npcGroup?.userData) return null;
+  if (!npcGroup.userData.__collisionChatState) {
+    npcGroup.userData.__collisionChatState = {
+      active: false,
+      timer: 0,
+      cooldown: 0,
+      partnerId: null,
+      partnerRef: null,
+      playing: null,
+    };
+  }
+  return npcGroup.userData.__collisionChatState;
+}
+
+function stopAllAnimations(group) {
+  const actions = group?.userData?.animations;
+  if (!actions) return;
+  try {
+    Object.values(actions).forEach((action) => action.stop());
+  } catch (_) {}
+}
+
+function pickChatAnimation(actions) {
+  if (!actions) return null;
+  const candidates = [
+    'standAndChat',
+    'talkWithRightHand',
+    'talking',
+    'idle12',
+    'idle11',
+    'idle',
+  ];
+  for (const name of candidates) {
+    if (actions[name]) return name;
+  }
+  const values = Object.keys(actions);
+  return values.length ? values[0] : null;
+}
+
+function playChatAnimation(group, state) {
+  const actions = group?.userData?.animations;
+  if (!actions) return;
+  const desired = pickChatAnimation(actions);
+  if (!desired) return;
+  if (state.playing === desired && group.userData?.currentAnimation === desired) return;
+  const action = actions[desired];
+  if (!action) return;
+  try {
+    stopAllAnimations(group);
+    action.reset();
+    action.setLoop(THREE.LoopRepeat);
+    action.clampWhenFinished = false;
+    action.play();
+    group.userData.currentAnimation = desired;
+    state.playing = desired;
+  } catch (_) {}
+}
+
+function endCollisionState(group, state, { setCooldown = true } = {}) {
+  if (!state) return;
+  state.active = false;
+  state.timer = 0;
+  state.partnerId = null;
+  state.partnerRef = null;
+  state.playing = null;
+  if (setCooldown) {
+    state.cooldown = COLLISION_CHAT_COOLDOWN;
+  }
+}
+
+function startCollisionChat(group, state, partner, partnerState) {
+  state.active = true;
+  state.timer = COLLISION_CHAT_DURATION;
+  state.partnerId = partner?.uuid || null;
+  state.partnerRef = partner || null;
+  state.playing = null;
+  state.cooldown = 0;
+
+  if (partnerState) {
+    partnerState.active = true;
+    partnerState.timer = COLLISION_CHAT_DURATION;
+    partnerState.partnerId = group?.uuid || null;
+    partnerState.partnerRef = group || null;
+    partnerState.playing = null;
+    partnerState.cooldown = 0;
+  }
+
+  playChatAnimation(group, state);
+  if (partner && partnerState) {
+    playChatAnimation(partner, partnerState);
+  }
+}
+
+export function ensureNpcCollisionIdle(npcGroup, delta, objectGrid) {
+  if (!npcGroup || !npcGroup.userData) return false;
+  if (npcGroup.userData.interacting) return false;
+
+  const ai = npcGroup.userData.ai;
+  if (ai && ai.conversationActive) return false;
+
+  const state = ensureCollisionState(npcGroup);
+  if (!state) return false;
+
+  if (state.cooldown > 0) {
+    state.cooldown = Math.max(0, state.cooldown - (Number(delta) || 0));
+  }
+
+  if (state.active) {
+    state.timer -= Number(delta) || 0;
+    const partner = state.partnerRef;
+    const stillPartnered =
+      partner &&
+      partner.userData &&
+      partner.userData.__collisionChatState &&
+      partner.userData.__collisionChatState.partnerId === npcGroup.uuid &&
+      partner.userData.__collisionChatState.active;
+    if (state.timer <= 0 || !stillPartnered) {
+      if (partner?.userData?.__collisionChatState) {
+        endCollisionState(partner, partner.userData.__collisionChatState);
+      }
+      endCollisionState(npcGroup, state);
+      return false;
+    }
+    playChatAnimation(npcGroup, state);
+    return true;
+  }
+
+  if (!objectGrid || typeof objectGrid.getObjectsNear !== 'function') {
+    return false;
+  }
+
+  const colliderRadius = npcGroup.userData?.collider?.radius ?? 2.0;
+  const searchRadius = colliderRadius + COLLISION_CHAT_SEARCH_PADDING;
+  let nearby;
+  try {
+    nearby = objectGrid.getObjectsNear(npcGroup.position, searchRadius) || [];
+  } catch (_) {
+    nearby = [];
+  }
+
+  for (const candidate of nearby) {
+    if (!candidate || candidate === npcGroup) continue;
+    if (candidate.userData?.type !== 'npc') continue;
+    if (candidate.userData.interacting) continue;
+
+    const otherState = ensureCollisionState(candidate);
+    if (!otherState) continue;
+    if (otherState.active && otherState.partnerId !== npcGroup.uuid) continue;
+    if (state.cooldown > 0 || otherState.cooldown > 0) continue;
+
+    const otherRadius = candidate.userData?.collider?.radius ?? 2.0;
+    const totalRadius = Math.max(0.1, colliderRadius + otherRadius);
+    const dx = candidate.position.x - npcGroup.position.x;
+    const dz = candidate.position.z - npcGroup.position.z;
+    const distSq = dx * dx + dz * dz;
+    if (distSq > totalRadius * totalRadius) continue;
+
+    const myId = npcGroup.uuid || '';
+    const otherId = candidate.uuid || '';
+    if (myId > otherId) {
+      // Let the consistently ordered instance initiate the chat to avoid double-starts.
+      continue;
+    }
+
+    startCollisionChat(npcGroup, state, candidate, otherState);
+    return true;
+  }
+
+  return false;
+}

--- a/src/scene/animationLoop.js
+++ b/src/scene/animationLoop.js
@@ -4,6 +4,7 @@ import { updatePlayer } from '../game/player/index.js';
 import { updateWanderFree } from '/src/game/npcs/behaviors/wanderFree.js';
 import { updateRoadPatrol } from '/src/game/npcs/behaviors/roadPatrol.js';
 import { updateNarutoRoutine } from '/src/game/npcs/behaviors/narutoRoutine.js';
+import { ensureNpcCollisionIdle } from '/src/game/npcs/common.js';
 import { INTERACTION_DISTANCE } from '../game/constants.js';
 import { multiplayerManager } from '../network/multiplayerManager.js';
 
@@ -320,6 +321,7 @@ export function startAnimationLoop({
                             }
                         }
                     } catch (_) {}
+                    try { ensureNpcCollisionIdle(g, delta, objectGridRef.current); } catch (_) {}
                     // Per-NPC behavior hooks
                     try { updateWanderFree(g, delta, objectGridRef.current); } catch (_) {}
                     try { updateRoadPatrol(g, delta, objectGridRef.current); } catch (_) {}


### PR DESCRIPTION
## Summary
- add a shared NPC collision helper that triggers stand-and-chat style animations for 15 seconds
- integrate the collision pause across wander, patrol, Naruto routines, and the global loop so every NPC respects it
- document the change in `changes.md`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e024bd44088332b2b6145dacc2ff52