### PR TITLE
Add Naruto-style routines for all NPCs

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -57,3 +57,5 @@ Recent
 - World: Added a gradient skysphere plus sun and moon sprites that follow the dynamic day-night cycle.
 
 - NPCs: Colliding characters now pause for 15s and play stand-and-chat style idles before resuming their routes.
+- NPCs: Naruto-style patrol routines now drive all squad members with character-specific pacing and roam radii.
+- NPCs: Added dedicated behavior modules for Sasuke, Sakura, Shikamaru, Neji, and Orochimaru that plug into the shared updater.

--- a/src/game/npcs/behaviors/narutoRoutine.js
+++ b/src/game/npcs/behaviors/narutoRoutine.js
@@ -74,7 +74,10 @@ function playIdleAnimation(npcGroup) {
 
 function ensureModeQueue(routine) {
   if (!Array.isArray(routine.modeQueue) || routine.modeQueue.length === 0) {
-    routine.modeQueue = shuffle(MODE_POOL);
+    const pool = Array.isArray(routine.modePool) && routine.modePool.length > 0
+      ? routine.modePool
+      : MODE_POOL;
+    routine.modeQueue = shuffle(pool);
   }
 }
 
@@ -191,28 +194,46 @@ function startReturn(npcGroup, routine) {
 
 export function attachNarutoRoutine(npcGroup, options = {}) {
   if (!npcGroup) return;
-  const spawn = options.spawnPosition && options.spawnPosition.isVector3
-    ? options.spawnPosition.clone()
+  const {
+    spawnPosition,
+    wanderRadius,
+    wanderMin,
+    wanderMax,
+    returnTolerance,
+    routineKey = '__narutoRoutine',
+    modePool,
+    startMode = 'walk',
+  } = options || {};
+  const spawn = spawnPosition && spawnPosition.isVector3
+    ? spawnPosition.clone()
     : npcGroup.position.clone();
   const routine = {
     state: 'init',
     spawn,
-    wanderRadius: Math.max(8, options.wanderRadius || WANDER_RADIUS),
-    wanderMin: Math.max(10, options.wanderMin ?? WANDER_DURATION_MIN),
-    wanderMax: Math.max(options.wanderMin ?? WANDER_DURATION_MIN, options.wanderMax ?? WANDER_DURATION_MAX),
-    returnTolerance: options.returnTolerance ?? RETURN_TOLERANCE,
+    wanderRadius: Math.max(8, wanderRadius || WANDER_RADIUS),
+    wanderMin: Math.max(10, wanderMin ?? WANDER_DURATION_MIN),
+    wanderMax: Math.max(wanderMin ?? WANDER_DURATION_MIN, wanderMax ?? WANDER_DURATION_MAX),
+    returnTolerance: returnTolerance ?? RETURN_TOLERANCE,
     modeQueue: [],
+    modePool: Array.isArray(modePool) && modePool.length > 0 ? modePool.slice() : MODE_POOL.slice(),
     loopTriggered: false,
     wanderTimer: 0,
     returnFromMode: null,
     lastPatrolMode: null,
+    key: routineKey,
+    startMode,
   };
-  npcGroup.userData.__narutoRoutine = routine;
-  startPatrol(npcGroup, routine, 'walk');
+  npcGroup.userData.__narutoRoutineKey = routineKey;
+  npcGroup.userData[routineKey] = routine;
+  if (routineKey !== '__narutoRoutine') {
+    npcGroup.userData.__narutoRoutine = routine;
+  }
+  startPatrol(npcGroup, routine, routine.startMode === 'run' ? 'run' : 'walk');
 }
 
 export function updateNarutoRoutine(npcGroup, delta, objectGrid) {
-  const routine = npcGroup?.userData?.__narutoRoutine;
+  const key = npcGroup?.userData?.__narutoRoutineKey || '__narutoRoutine';
+  const routine = npcGroup?.userData?.[key] || npcGroup?.userData?.__narutoRoutine;
   if (!routine) return;
   const collisionLocked = ensureNpcCollisionIdle(npcGroup, delta, objectGrid);
   if (npcGroup.userData?.interacting) {

--- a/src/game/npcs/behaviors/nejiRoutine.js
+++ b/src/game/npcs/behaviors/nejiRoutine.js
@@ -1,0 +1,21 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const NEJI_ROUTINE_KEY = '__nejiRoutine';
+
+export function attachNejiRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 22,
+    wanderMin: 13,
+    wanderMax: 32,
+    startMode: 'walk',
+    modePool: ['walk', 'run'],
+    returnTolerance: 1.2,
+    ...options,
+    routineKey: NEJI_ROUTINE_KEY,
+  });
+}
+
+export function updateNejiRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== NEJI_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/behaviors/orochimaruRoutine.js
+++ b/src/game/npcs/behaviors/orochimaruRoutine.js
@@ -1,0 +1,21 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const OROCHIMARU_ROUTINE_KEY = '__orochimaruRoutine';
+
+export function attachOrochimaruRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 30,
+    wanderMin: 10,
+    wanderMax: 28,
+    startMode: 'walk',
+    modePool: ['walk', 'run', 'run'],
+    returnTolerance: 2.0,
+    ...options,
+    routineKey: OROCHIMARU_ROUTINE_KEY,
+  });
+}
+
+export function updateOrochimaruRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== OROCHIMARU_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/behaviors/sakuraRoutine.js
+++ b/src/game/npcs/behaviors/sakuraRoutine.js
@@ -1,0 +1,20 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const SAKURA_ROUTINE_KEY = '__sakuraRoutine';
+
+export function attachSakuraRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 18,
+    wanderMin: 12,
+    wanderMax: 30,
+    startMode: 'walk',
+    modePool: ['walk', 'walk', 'run'],
+    ...options,
+    routineKey: SAKURA_ROUTINE_KEY,
+  });
+}
+
+export function updateSakuraRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== SAKURA_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/behaviors/sasukeRoutine.js
+++ b/src/game/npcs/behaviors/sasukeRoutine.js
@@ -1,0 +1,20 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const SASUKE_ROUTINE_KEY = '__sasukeRoutine';
+
+export function attachSasukeRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 26,
+    wanderMin: 11,
+    wanderMax: 26,
+    startMode: 'run',
+    modePool: ['run', 'walk'],
+    ...options,
+    routineKey: SASUKE_ROUTINE_KEY,
+  });
+}
+
+export function updateSasukeRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== SASUKE_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/behaviors/shikamaruRoutine.js
+++ b/src/game/npcs/behaviors/shikamaruRoutine.js
@@ -1,0 +1,21 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const SHIKAMARU_ROUTINE_KEY = '__shikamaruRoutine';
+
+export function attachShikamaruRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 14,
+    wanderMin: 18,
+    wanderMax: 38,
+    startMode: 'walk',
+    modePool: ['walk'],
+    returnTolerance: 1.5,
+    ...options,
+    routineKey: SHIKAMARU_ROUTINE_KEY,
+  });
+}
+
+export function updateShikamaruRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== SHIKAMARU_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/neji.js
+++ b/src/game/npcs/neji.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { createNpcRig } from './common.js';
-import { attachWanderFree } from './behaviors/wanderFree.js';
+import { attachNejiRoutine } from './behaviors/nejiRoutine.js';
 import { getPlayerIdentity } from '../player/identity.js';
 
 export function createNeji(scene, settings, position = new THREE.Vector3()) {
@@ -58,7 +58,7 @@ export function createNeji(scene, settings, position = new THREE.Vector3()) {
         } catch (_) {}
       };
     } catch (_) {}
-    try { attachWanderFree(group, { speed: 7.5 }); } catch (_) {}
+    try { attachNejiRoutine(group, { spawnPosition: group.position.clone() }); } catch (_) {}
     return group;
   });
 }

--- a/src/game/npcs/orochimaru.js
+++ b/src/game/npcs/orochimaru.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { createNpcRig } from './common.js';
-import { attachWanderFree } from './behaviors/wanderFree.js';
+import { attachOrochimaruRoutine } from './behaviors/orochimaruRoutine.js';
 import { getPlayerIdentity } from '../player/identity.js';
 
 export function createOrochimaru(scene, settings, position = new THREE.Vector3()) {
@@ -41,7 +41,7 @@ export function createOrochimaru(scene, settings, position = new THREE.Vector3()
         } catch (_) {}
       };
     } catch (_) {}
-    try { attachWanderFree(group, { speed: 6.5 }); } catch (_) {}
+    try { attachOrochimaruRoutine(group, { spawnPosition: group.position.clone() }); } catch (_) {}
     return group;
   });
 }

--- a/src/game/npcs/sakura.js
+++ b/src/game/npcs/sakura.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { createNpcRig } from './common.js';
-import { attachWanderFree } from './behaviors/wanderFree.js';
+import { attachSakuraRoutine } from './behaviors/sakuraRoutine.js';
 import { getPlayerIdentity } from '../player/identity.js';
 
 export function createSakura(scene, settings, position = new THREE.Vector3()) {
@@ -41,8 +41,9 @@ export function createSakura(scene, settings, position = new THREE.Vector3()) {
         } catch (_) {}
       };
     } catch (_) {}
-    // Give Sakura free-wander behavior
-    try { attachWanderFree(group, { speed: 7.5 }); } catch (_) {}
+    try {
+      attachSakuraRoutine(group, { spawnPosition: group.position.clone() });
+    } catch (_) {}
     return group;
   });
 }

--- a/src/game/npcs/sasuke.js
+++ b/src/game/npcs/sasuke.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { createNpcRig } from './common.js';
-import { attachWanderFree } from './behaviors/wanderFree.js';
+import { attachSasukeRoutine } from './behaviors/sasukeRoutine.js';
 import { getPlayerIdentity } from '../player/identity.js';
 
 export function createSasuke(scene, settings, position = new THREE.Vector3()) {
@@ -41,8 +41,9 @@ export function createSasuke(scene, settings, position = new THREE.Vector3()) {
         } catch (_) {}
       };
     } catch (_) {}
-    // Give Sasuke free-wander behavior
-    try { attachWanderFree(group, { speed: 10 }); } catch (_) {}
+    try {
+      attachSasukeRoutine(group, { spawnPosition: group.position.clone() });
+    } catch (_) {}
     return group;
   });
 }

--- a/src/game/npcs/shikamaru.js
+++ b/src/game/npcs/shikamaru.js
@@ -1,26 +1,7 @@
 import * as THREE from 'three';
 import { createNpcRig } from './common.js';
-import { attachWanderFree } from './behaviors/wanderFree.js';
-import { attachRoadPatrol } from './behaviors/roadPatrol.js';
+import { attachShikamaruRoutine } from './behaviors/shikamaruRoutine.js';
 import { getPlayerIdentity } from '../player/identity.js';
-import { loadKonohaRoads } from '/src/components/game/objects/konoha_roads.js';
-import { WORLD_SIZE } from '/src/scene/terrain.js';
-
-const WORLD_HALF = WORLD_SIZE / 2;
-
-function districtPolygonToWorld(points) {
-  if (!Array.isArray(points)) return null;
-  const poly = points
-    .map((point) => {
-      if (!Array.isArray(point) || point.length < 2) return null;
-      const x = (Number(point[0]) / 100) * WORLD_SIZE - WORLD_HALF;
-      const z = (Number(point[1]) / 100) * WORLD_SIZE - WORLD_HALF;
-      if (!Number.isFinite(x) || !Number.isFinite(z)) return null;
-      return { x, z };
-    })
-    .filter(Boolean);
-  return poly.length >= 3 ? poly : null;
-}
 
 export function createShikamaru(scene, settings, position = new THREE.Vector3()) {
   return createNpcRig({
@@ -60,50 +41,9 @@ export function createShikamaru(scene, settings, position = new THREE.Vector3())
         } catch (_) {}
       };
     } catch (_) {}
-    const applyRoam = (polygon) => {
-      const fallbackWander = () => {
-        const options = { speed: 5.5 };
-        if (polygon) {
-          options.keepWithinPolygon = polygon;
-        }
-        try { attachWanderFree(group, options); } catch (_) {}
-      };
-
-      try {
-        attachRoadPatrol(group, {
-          speed: 5.6,
-          pauseChance: 0.55,
-          pauseMin: 1.2,
-          pauseMax: 3.8,
-          minRoadWidth: 2.5,
-          restrictToPolygon: polygon,
-          deviation: {
-            chance: 0.45,
-            radius: polygon ? 14 : 18,
-            speed: 5,
-            durationMin: 2,
-            durationMax: 22,
-            pauseChance: 0.55,
-            pauseMin: 0.9,
-            pauseMax: 3.2,
-            radiusCollision: group.userData?.collider?.radius ?? 2.0,
-          },
-          onError: fallbackWander,
-        });
-      } catch (_) {
-        fallbackWander();
-      }
-    };
-
-    loadKonohaRoads()
-      .then(({ districts }) => {
-        const district = districts?.Nara || districts?.nara;
-        const polygon = districtPolygonToWorld(district?.points);
-        applyRoam(polygon);
-      })
-      .catch(() => {
-        applyRoam(null);
-      });
+    try {
+      attachShikamaruRoutine(group, { spawnPosition: group.position.clone() });
+    } catch (_) {}
     return group;
   });
 }

--- a/src/scene/animationLoop.js
+++ b/src/scene/animationLoop.js
@@ -4,6 +4,11 @@ import { updatePlayer } from '../game/player/index.js';
 import { updateWanderFree } from '/src/game/npcs/behaviors/wanderFree.js';
 import { updateRoadPatrol } from '/src/game/npcs/behaviors/roadPatrol.js';
 import { updateNarutoRoutine } from '/src/game/npcs/behaviors/narutoRoutine.js';
+import { updateSasukeRoutine } from '/src/game/npcs/behaviors/sasukeRoutine.js';
+import { updateSakuraRoutine } from '/src/game/npcs/behaviors/sakuraRoutine.js';
+import { updateShikamaruRoutine } from '/src/game/npcs/behaviors/shikamaruRoutine.js';
+import { updateNejiRoutine } from '/src/game/npcs/behaviors/nejiRoutine.js';
+import { updateOrochimaruRoutine } from '/src/game/npcs/behaviors/orochimaruRoutine.js';
 import { ensureNpcCollisionIdle } from '/src/game/npcs/common.js';
 import { INTERACTION_DISTANCE } from '../game/constants.js';
 import { multiplayerManager } from '../network/multiplayerManager.js';
@@ -326,6 +331,11 @@ export function startAnimationLoop({
                     try { updateWanderFree(g, delta, objectGridRef.current); } catch (_) {}
                     try { updateRoadPatrol(g, delta, objectGridRef.current); } catch (_) {}
                     try { updateNarutoRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateSasukeRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateSakuraRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateShikamaruRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateNejiRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateOrochimaruRoutine(g, delta, objectGridRef.current); } catch (_) {}
                     // Ensure mixer advances regardless
                     try { g?.userData?.mixer?.update(delta); } catch (_) {}
                 }


### PR DESCRIPTION
## Summary
- add individual Naruto-style behavior wrappers for Sasuke, Sakura, Shikamaru, Neji, and Orochimaru
- allow the shared Naruto routine to support configurable keys and patrol presets for each NPC
- wire the animation loop to tick the new routines and document the change in the repo changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0271605f48332a643866139adaf71