### PR TITLE
Keep NPC spatial grid updated for moving NPCs

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -59,3 +59,4 @@ Recent
 - NPCs: Colliding characters now pause for 15s and play stand-and-chat style idles before resuming their routes.
 - NPCs: Naruto-style patrol routines now drive all squad members with character-specific pacing and roam radii.
 - NPCs: Added dedicated behavior modules for Sasuke, Sakura, Shikamaru, Neji, and Orochimaru that plug into the shared updater.
+- NPCs: Keep the spatial grid in sync with moving characters so patrol animations play and chat collisions trigger reliably.

--- a/src/game/objects/grid.js
+++ b/src/game/objects/grid.js
@@ -5,6 +5,7 @@ export class ObjectGrid {
         this.grid = {};
         this.halfWorldSize = worldSize / 2;
         this.numCells = Math.ceil(worldSize / cellSize);
+        this.objectLookup = new WeakMap();
     }
 
     _getGridCoords(position) {
@@ -17,11 +18,55 @@ export class ObjectGrid {
         return `${coords.x},${coords.z}`;
     }
 
-    add(object) {
+    _ensureCell(key) {
+        if (!this.grid[key]) this.grid[key] = [];
+        return this.grid[key];
+    }
+
+    _addToCell(key, object) {
+        const cell = this._ensureCell(key);
+        if (!cell.includes(object)) {
+            cell.push(object);
+        }
+        this.objectLookup.set(object, key);
+    }
+
+    _removeFromCell(key, object) {
+        const cell = this.grid[key];
+        if (!cell) return;
+        const index = cell.indexOf(object);
+        if (index !== -1) {
+            cell.splice(index, 1);
+        }
+        if (cell.length === 0) {
+            delete this.grid[key];
+        }
+    }
+
+    _placeObject(object) {
+        if (!object?.position) return;
         const coords = this._getGridCoords(object.position);
         const key = this._getKey(coords);
-        if (!this.grid[key]) this.grid[key] = [];
-        this.grid[key].push(object);
+        const previousKey = this.objectLookup.get(object);
+        if (previousKey && previousKey !== key) {
+            this._removeFromCell(previousKey, object);
+        }
+        this._addToCell(key, object);
+    }
+
+    add(object) {
+        this._placeObject(object);
+    }
+
+    update(object) {
+        this._placeObject(object);
+    }
+
+    remove(object) {
+        const key = this.objectLookup.get(object);
+        if (!key) return;
+        this._removeFromCell(key, object);
+        this.objectLookup.delete(object);
     }
 
     getObjectsNear(position, radius) {
@@ -42,5 +87,6 @@ export class ObjectGrid {
 
     clear() {
         this.grid = {};
+        this.objectLookup = new WeakMap();
     }
 }

--- a/src/scene/animationLoop.js
+++ b/src/scene/animationLoop.js
@@ -316,14 +316,11 @@ export function startAnimationLoop({
             if (Array.isArray(npcs)) {
                 for (let i = 0; i < npcs.length; i++) {
                     const g = npcs[i];
-                    // Ensure NPC is in spatial grid to enable collisions/interactions
+                    // Ensure NPC stays registered with the spatial grid for collisions/interactions
                     try {
                         const grid = objectGridRef.current;
                         if (grid && g && g.position) {
-                            if (g.userData.__gridRef !== grid) {
-                                grid.add(g);
-                                g.userData.__gridRef = grid;
-                            }
+                            grid.update(g);
                         }
                     } catch (_) {}
                     try { ensureNpcCollisionIdle(g, delta, objectGridRef.current); } catch (_) {}


### PR DESCRIPTION
## Summary
- teach the object grid to track which cell each object occupies and retarget entries when they move
- refresh the animation loop to update NPC registrations every frame so patrol logic and collision chats stay active
- log the behavior fix in the running changes.md changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e02afb5a0c8332b77af0218f1195f6