### PR TITLE
Position Sasuke and Sakura at specified grid cells

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -44,6 +44,8 @@ Recent
 
 - Tooling: Added Vitest setup with testing dependencies and scripts for component testing.
 
+- NPCs: Relocated Sasuke to LN318 and Sakura to KN318 so they deploy at their intended grid cells.
+
 - Tests: Added character catalog coverage to ensure identity, stats, and inventory builders clone data and honor overrides.
 
 - Tests: Added district layout utility coverage for normalization, cloning, caching, and reload paths.

--- a/src/hooks/sceneLifecycle.js
+++ b/src/hooks/sceneLifecycle.js
@@ -63,8 +63,8 @@ export function initThreeScene({
 
             const spawnEntries = [
               { key: 'naruto', label: 'Naruto', spawnLabel: 'MO382', create: createNaruto },
-              { key: 'sasuke', label: 'Sasuke', offset: new THREE.Vector3(-6, 0, 0), create: createSasuke },
-              { key: 'sakura', label: 'Sakura', offset: new THREE.Vector3(0, 0, 6), create: createSakura },
+              { key: 'sasuke', label: 'Sasuke', spawnLabel: 'LN318', create: createSasuke },
+              { key: 'sakura', label: 'Sakura', spawnLabel: 'KN318', create: createSakura },
               { key: 'shikamaru', label: 'Shikamaru', spawnLabel: 'RJ416', create: createShikamaru },
               { key: 'neji', label: 'Neji', offset: new THREE.Vector3(8, 0, 8), create: createNeji },
               { key: 'orochimaru', label: 'Orochimaru', offset: new THREE.Vector3(-8, 0, 8), create: createOrochimaru }


### PR DESCRIPTION
## Summary
- spawn Sasuke directly at grid LN318 and Sakura at KN318 during scene setup
- document the new squad deployment coordinates in the running changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e03000255c8332adfb62067cb6e653