### PR TITLE
Fix NPC interaction lock sticking after dialogs

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -63,3 +63,4 @@ Recent
 - NPCs: Naruto-style patrol routines now drive all squad members with character-specific pacing and roam radii.
 - NPCs: Added dedicated behavior modules for Sasuke, Sakura, Shikamaru, Neji, and Orochimaru that plug into the shared updater.
 - NPCs: Keep the spatial grid in sync with moving characters so patrol animations play and chat collisions trigger reliably.
+- NPC Dialog: Release the interaction lock when conversations close so squadmates resume their patrol animations.

--- a/src/OpenWorldGame.jsx
+++ b/src/OpenWorldGame.jsx
@@ -261,6 +261,7 @@ const OpenWorldGame = () => {
   const musicWasPlayingRef = useRef(false);
   const [showNpcDialog, setShowNpcDialog] = useState(false);
   const [npcDialogData, setNpcDialogData] = useState(null);
+  const npcDialogWasOpenRef = useRef(false);
   const releasePauseMenu = useCallback(() => {
     const wasPausedBefore = window.__pauseMenuWasPausedBefore;
     delete window.__pauseMenuActive;
@@ -319,6 +320,22 @@ const OpenWorldGame = () => {
       window.removeEventListener("open-npc-dialog", openNpc);
     };
   }, []);
+  useEffect(() => {
+    const wasOpen = npcDialogWasOpenRef.current;
+    npcDialogWasOpenRef.current = showNpcDialog;
+    if (wasOpen && !showNpcDialog) {
+      try { window.__npcDialogActive = false; } catch (_) {}
+      try { window.__clearPlayerControlState?.(); } catch (_) {}
+      try {
+        if (window.__npcInteracting) {
+          window.__npcInteracting.userData.interacting = false;
+          delete window.__npcInteracting;
+        }
+      } catch (_) {}
+      try { delete window.__resumePointerLockAfterDialog; } catch (_) {}
+      try { delete window.__suspendPointerLockSync; } catch (_) {}
+    }
+  }, [showNpcDialog]);
   const getInitialLoadingSteps = React.useCallback(() => ([
     {
       id: 'prefetch',


### PR DESCRIPTION
## Summary
- ensure NPC dialogs clear the interaction lock when they close so NPCs resume wandering
- note the dialog behavior change in the running changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e041ac079c8332b807181be2fdb155