### PR TITLE
Fix NPC chat animation reset

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -64,3 +64,4 @@ Recent
 - NPCs: Added dedicated behavior modules for Sasuke, Sakura, Shikamaru, Neji, and Orochimaru that plug into the shared updater.
 - NPCs: Keep the spatial grid in sync with moving characters so patrol animations play and chat collisions trigger reliably.
 - NPC Dialog: Release the interaction lock when conversations close so squadmates resume their patrol animations.
+- NPCs: Reset post-chat animations when collision conversations end so walkers immediately return to their locomotion cycles.

--- a/src/game/npcs/common.js
+++ b/src/game/npcs/common.js
@@ -275,6 +275,14 @@ function endCollisionState(group, state, { setCooldown = true } = {}) {
   state.partnerId = null;
   state.partnerRef = null;
   state.playing = null;
+  // Ensure any lingering interaction animation is cleared so locomotion logic
+  // can immediately pick the correct idle/walk cycle next frame.
+  try {
+    stopAllAnimations(group);
+    if (group?.userData) {
+      group.userData.currentAnimation = null;
+    }
+  } catch (_) {}
   if (setCooldown) {
     state.cooldown = COLLISION_CHAT_COOLDOWN;
   }


### PR DESCRIPTION
## Summary
- clear residual NPC chat animations when collision conversations end
- ensure wander logic can immediately resume idle or walking cycles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0444dc4f88332b8720f9e58223d49