### PR TITLE
Fix NPC interaction animations and resume patrols

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -65,3 +65,4 @@ Recent
 - NPCs: Keep the spatial grid in sync with moving characters so patrol animations play and chat collisions trigger reliably.
 - NPC Dialog: Release the interaction lock when conversations close so squadmates resume their patrol animations.
 - NPCs: Reset post-chat animations when collision conversations end so walkers immediately return to their locomotion cycles.
+- NPC Dialog: Interacting with NPCs now freezes their patrol movement, plays listening/chat poses, and resumes routes after the dialogue closes.

--- a/src/game/npcs/behaviors/narutoRoutine.js
+++ b/src/game/npcs/behaviors/narutoRoutine.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
-import { ensureNpcCollisionIdle } from '../common.js';
+import { ensureNpcCollisionIdle, playNpcInteractionAnimation } from '../common.js';
 import { attachRoadPatrol } from './roadPatrol.js';
 import { attachWanderFree } from './wanderFree.js';
 
@@ -237,8 +237,14 @@ export function updateNarutoRoutine(npcGroup, delta, objectGrid) {
   if (!routine) return;
   const collisionLocked = ensureNpcCollisionIdle(npcGroup, delta, objectGrid);
   if (npcGroup.userData?.interacting) {
-    playIdleAnimation(npcGroup);
+    try { npcGroup.userData.__wasInteractingRoutine = true; } catch (_) {}
+    try { playNpcInteractionAnimation(npcGroup); } catch (_) {}
     return;
+  }
+
+  if (npcGroup.userData?.__wasInteractingRoutine) {
+    try { npcGroup.userData.currentAnimation = null; } catch (_) {}
+    try { npcGroup.userData.__wasInteractingRoutine = false; } catch (_) {}
   }
 
   if (routine.state === 'patrol') {

--- a/src/game/npcs/behaviors/roadPatrol.js
+++ b/src/game/npcs/behaviors/roadPatrol.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
 import { loadKonohaRoads } from '/src/components/game/objects/konoha_roads.js';
 import { WORLD_SIZE } from '/src/scene/terrain.js';
-import { ensureNpcCollisionIdle } from '../common.js';
+import { ensureNpcCollisionIdle, playNpcInteractionAnimation } from '../common.js';
 
 const WORLD_HALF = WORLD_SIZE / 2;
 
@@ -442,6 +442,17 @@ export function updateRoadPatrol(npcGroup, delta, objectGrid) {
   if (!ai || ai.type !== 'roadPatrol') return;
 
   const collisionLocked = ensureNpcCollisionIdle(npcGroup, delta, objectGrid);
+
+  if (npcGroup.userData?.interacting) {
+    ai.__pausedForInteraction = true;
+    try { playNpcInteractionAnimation(npcGroup); } catch (_) {}
+    return;
+  }
+
+  if (ai.__pausedForInteraction) {
+    ai.__pausedForInteraction = false;
+    try { npcGroup.userData.currentAnimation = null; } catch (_) {}
+  }
 
   if (ai.wait > 0) {
     ai.wait -= delta;

--- a/src/game/npcs/behaviors/wanderFree.js
+++ b/src/game/npcs/behaviors/wanderFree.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
-import { ensureNpcCollisionIdle } from '../common.js';
+import { ensureNpcCollisionIdle, playNpcInteractionAnimation } from '../common.js';
 
 function normalizePolygon(points) {
   if (!Array.isArray(points)) return null;
@@ -158,33 +158,9 @@ export function updateWanderFree(npcGroup, delta, objectGrid) {
     return;
   }
 
-  // If interacting, freeze in place and play idle
+  // If interacting, freeze in place and play a conversation/listening pose
   if (npcGroup.userData?.interacting) {
-    try {
-      const actions = npcGroup.userData.animations || {};
-      const preferred = actions.idle12 ? 'idle12' : (actions.idle11 ? 'idle11' : (actions.idle ? 'idle' : null));
-      if (preferred) {
-        const action = actions[preferred];
-        const alreadyPlaying = npcGroup.userData.currentAnimation === preferred && isActionRunning(action);
-        if (!alreadyPlaying) {
-          Object.values(actions).forEach((a) => {
-            try { a.stop(); } catch (_) {}
-          });
-          try {
-            action.clampWhenFinished = false;
-            action.enabled = true;
-            action.paused = false;
-            action.reset();
-            action.setLoop(THREE.LoopRepeat);
-            action.play();
-          } catch (_) {}
-          npcGroup.userData.currentAnimation = preferred;
-        }
-      } else {
-        try { Object.values(actions).forEach((a) => { try { a.stop(); } catch (_) {}; }); } catch (_) {}
-        npcGroup.userData.currentAnimation = null;
-      }
-    } catch (_) {}
+    try { playNpcInteractionAnimation(npcGroup); } catch (_) {}
     try { npcGroup.userData.__wasInteracting = true; } catch (_) {}
     return;
   }

--- a/src/game/npcs/common.js
+++ b/src/game/npcs/common.js
@@ -235,6 +235,7 @@ function stopAllAnimations(group) {
 function pickChatAnimation(actions) {
   if (!actions) return null;
   const candidates = [
+    'listeningGesture',
     'standAndChat',
     'talkWithRightHand',
     'talking',
@@ -249,23 +250,51 @@ function pickChatAnimation(actions) {
   return values.length ? values[0] : null;
 }
 
-function playChatAnimation(group, state) {
+function isActionRunning(action) {
+  if (!action) return false;
+  if (typeof action.isRunning === 'function') {
+    try {
+      return action.isRunning();
+    } catch (_) {
+      return !!action.enabled && !action.paused;
+    }
+  }
+  return !!action.enabled && !action.paused;
+}
+
+export function playNpcInteractionAnimation(group) {
   const actions = group?.userData?.animations;
-  if (!actions) return;
+  if (!actions) return false;
   const desired = pickChatAnimation(actions);
-  if (!desired) return;
-  if (state.playing === desired && group.userData?.currentAnimation === desired) return;
+  if (!desired) return false;
   const action = actions[desired];
-  if (!action) return;
+  if (!action) return false;
+  const targetName = action._clip?.name || desired;
+  if (group?.userData?.currentAnimation === targetName && isActionRunning(action)) {
+    return true;
+  }
   try {
     stopAllAnimations(group);
+    action.clampWhenFinished = false;
+    action.enabled = true;
+    action.paused = false;
     action.reset();
     action.setLoop(THREE.LoopRepeat);
-    action.clampWhenFinished = false;
     action.play();
-    group.userData.currentAnimation = desired;
-    state.playing = desired;
-  } catch (_) {}
+    if (group?.userData) {
+      group.userData.currentAnimation = targetName;
+    }
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function playChatAnimation(group, state) {
+  const played = playNpcInteractionAnimation(group);
+  if (played && group?.userData?.currentAnimation) {
+    state.playing = group.userData.currentAnimation;
+  }
 }
 
 function endCollisionState(group, state, { setCooldown = true } = {}) {


### PR DESCRIPTION
## Summary
- prefer listening/chat animations when NPCs talk to the player
- pause road patrol and routine behaviors while a conversation is active and resume them cleanly afterward
- log the dialog fix in the running changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e15d8798888332806193d83df99381