### PR TITLE
Freeze NPC patrol movement during interactions

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -66,3 +66,5 @@ Recent
 - NPC Dialog: Release the interaction lock when conversations close so squadmates resume their patrol animations.
 - NPCs: Reset post-chat animations when collision conversations end so walkers immediately return to their locomotion cycles.
 - NPC Dialog: Interacting with NPCs now freezes their patrol movement, plays listening/chat poses, and resumes routes after the dialogue closes.
+
+- NPCs: Freeze every squadmate in place during player conversations and resume their patrol paths immediately after dialogues close.

--- a/src/game/npcs/behaviors/narutoRoutine.js
+++ b/src/game/npcs/behaviors/narutoRoutine.js
@@ -1,6 +1,11 @@
 import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
-import { ensureNpcCollisionIdle, playNpcInteractionAnimation } from '../common.js';
+import {
+  ensureNpcCollisionIdle,
+  playNpcInteractionAnimation,
+  lockNpcInteractionPosition,
+  releaseNpcInteractionPosition,
+} from '../common.js';
 import { attachRoadPatrol } from './roadPatrol.js';
 import { attachWanderFree } from './wanderFree.js';
 
@@ -237,10 +242,13 @@ export function updateNarutoRoutine(npcGroup, delta, objectGrid) {
   if (!routine) return;
   const collisionLocked = ensureNpcCollisionIdle(npcGroup, delta, objectGrid);
   if (npcGroup.userData?.interacting) {
+    try { lockNpcInteractionPosition(npcGroup); } catch (_) {}
     try { npcGroup.userData.__wasInteractingRoutine = true; } catch (_) {}
     try { playNpcInteractionAnimation(npcGroup); } catch (_) {}
     return;
   }
+
+  try { releaseNpcInteractionPosition(npcGroup); } catch (_) {}
 
   if (npcGroup.userData?.__wasInteractingRoutine) {
     try { npcGroup.userData.currentAnimation = null; } catch (_) {}

--- a/src/game/npcs/behaviors/roadPatrol.js
+++ b/src/game/npcs/behaviors/roadPatrol.js
@@ -2,7 +2,12 @@ import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
 import { loadKonohaRoads } from '/src/components/game/objects/konoha_roads.js';
 import { WORLD_SIZE } from '/src/scene/terrain.js';
-import { ensureNpcCollisionIdle, playNpcInteractionAnimation } from '../common.js';
+import {
+  ensureNpcCollisionIdle,
+  playNpcInteractionAnimation,
+  lockNpcInteractionPosition,
+  releaseNpcInteractionPosition,
+} from '../common.js';
 
 const WORLD_HALF = WORLD_SIZE / 2;
 
@@ -444,10 +449,13 @@ export function updateRoadPatrol(npcGroup, delta, objectGrid) {
   const collisionLocked = ensureNpcCollisionIdle(npcGroup, delta, objectGrid);
 
   if (npcGroup.userData?.interacting) {
+    try { lockNpcInteractionPosition(npcGroup); } catch (_) {}
     ai.__pausedForInteraction = true;
     try { playNpcInteractionAnimation(npcGroup); } catch (_) {}
     return;
   }
+
+  try { releaseNpcInteractionPosition(npcGroup); } catch (_) {}
 
   if (ai.__pausedForInteraction) {
     ai.__pausedForInteraction = false;

--- a/src/game/npcs/behaviors/wanderFree.js
+++ b/src/game/npcs/behaviors/wanderFree.js
@@ -1,6 +1,11 @@
 import * as THREE from 'three';
 import { resolveCollisions } from '/src/game/player/movement/collision.js';
-import { ensureNpcCollisionIdle, playNpcInteractionAnimation } from '../common.js';
+import {
+  ensureNpcCollisionIdle,
+  playNpcInteractionAnimation,
+  lockNpcInteractionPosition,
+  releaseNpcInteractionPosition,
+} from '../common.js';
 
 function normalizePolygon(points) {
   if (!Array.isArray(points)) return null;
@@ -160,10 +165,13 @@ export function updateWanderFree(npcGroup, delta, objectGrid) {
 
   // If interacting, freeze in place and play a conversation/listening pose
   if (npcGroup.userData?.interacting) {
+    try { lockNpcInteractionPosition(npcGroup); } catch (_) {}
     try { playNpcInteractionAnimation(npcGroup); } catch (_) {}
     try { npcGroup.userData.__wasInteracting = true; } catch (_) {}
     return;
   }
+
+  try { releaseNpcInteractionPosition(npcGroup); } catch (_) {}
 
   if (npcGroup.userData?.__wasInteracting && !npcGroup.userData.interacting) {
     try { npcGroup.userData.currentAnimation = null; } catch (_) {}

--- a/src/game/npcs/common.js
+++ b/src/game/npcs/common.js
@@ -290,6 +290,47 @@ export function playNpcInteractionAnimation(group) {
   }
 }
 
+export function lockNpcInteractionPosition(group) {
+  if (!group || !group.position || !group.userData) return;
+  try {
+    if (!group.userData.__interactionLockPosition) {
+      if (typeof group.position.clone === 'function') {
+        group.userData.__interactionLockPosition = group.position.clone();
+      } else {
+        group.userData.__interactionLockPosition = {
+          x: Number(group.position.x) || 0,
+          y: Number(group.position.y) || 0,
+          z: Number(group.position.z) || 0,
+        };
+      }
+    }
+
+    const lock = group.userData.__interactionLockPosition;
+    if (!lock) return;
+
+    if (typeof group.position.copy === 'function' && lock?.isVector3) {
+      group.position.copy(lock);
+    } else if (
+      typeof lock.x === 'number' &&
+      typeof lock.y === 'number' &&
+      typeof lock.z === 'number'
+    ) {
+      group.position.x = lock.x;
+      group.position.y = lock.y;
+      group.position.z = lock.z;
+    }
+  } catch (_) {}
+}
+
+export function releaseNpcInteractionPosition(group) {
+  if (!group?.userData?.__interactionLockPosition) return;
+  try {
+    delete group.userData.__interactionLockPosition;
+  } catch (_) {
+    group.userData.__interactionLockPosition = null;
+  }
+}
+
 function playChatAnimation(group, state) {
   const played = playNpcInteractionAnimation(group);
   if (played && group?.userData?.currentAnimation) {


### PR DESCRIPTION
## Summary
- add shared helpers to lock and release NPC positions while the player is in dialogue
- update wander, road patrol, and naruto routines to pin characters during interactions and restore locomotion afterwards
- extend the running changelog with the new interaction behaviour

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1605302d4833297dc7a63f0334e6a