### PR TITLE
Add legendary NPCs with tailored patrol routines

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -68,3 +68,6 @@ Recent
 - NPCs: Keep the spatial grid in sync with moving characters so patrol animations play and chat collisions trigger reliably.
 - NPC Dialog: Release the interaction lock when conversations close so squadmates resume their patrol animations.
 - Campaign: Redesigned the campaign modal with an 80% viewport layout and tabbed sections for cleaner navigation.
+
+- NPCs: Added Hashirama, Jiraiya, Killer Bee, Rock Lee, and Tsunade with bespoke patrol tuning and dialog badges.
+- Systems: Expanded squad spawning and roster fallbacks so the new legends join existing patrol updates.

--- a/src/OpenWorldGame.jsx
+++ b/src/OpenWorldGame.jsx
@@ -216,7 +216,19 @@ const OpenWorldGame = () => {
     }
 
     if (stepId !== 'squad') return;
-    const fallbackRoster = ['Naruto', 'Sasuke', 'Sakura', 'Shikamaru', 'Neji', 'Orochimaru'];
+    const fallbackRoster = [
+      'Naruto',
+      'Sasuke',
+      'Sakura',
+      'Shikamaru',
+      'Neji',
+      'Orochimaru',
+      'Hashirama',
+      'Jiraiya',
+      'Killer Bee',
+      'Rock Lee',
+      'Tsunade'
+    ];
     const roster = Array.isArray(payload?.roster) && payload.roster.length ? payload.roster : fallbackRoster;
     if (status === 'active') {
       const note = roster.length

--- a/src/game/npcs/behaviors/hashiramaRoutine.js
+++ b/src/game/npcs/behaviors/hashiramaRoutine.js
@@ -1,0 +1,50 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const HASHIRAMA_ROUTINE_KEY = '__hashiramaRoutine';
+
+export function attachHashiramaRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 26,
+    wanderMin: 20,
+    wanderMax: 42,
+    wanderCenterJitter: 6,
+    modePool: ['walk', 'run', 'walk'],
+    startMode: 'walk',
+    wanderSettings: {
+      pauseChance: 0.58,
+      pauseMin: 1.2,
+      pauseMax: 4.8,
+      dirChangeMin: 1.6,
+      dirChangeMax: 3.6,
+    },
+    modeProfiles: {
+      walk: {
+        pauseChance: 0.42,
+        deviation: {
+          chance: 0.5,
+          radiusMultiplier: 0.95,
+        },
+      },
+      run: {
+        pauseChance: 0.18,
+        pauseMin: 0.6,
+        pauseMax: 1.8,
+        deviation: {
+          chance: 0.32,
+          radiusMultiplier: 0.75,
+        },
+      },
+    },
+    returnSpeeds: {
+      walk: 6.8,
+      run: 9.2,
+    },
+    ...options,
+    routineKey: HASHIRAMA_ROUTINE_KEY,
+  });
+}
+
+export function updateHashiramaRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== HASHIRAMA_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/behaviors/jiraiyaRoutine.js
+++ b/src/game/npcs/behaviors/jiraiyaRoutine.js
@@ -1,0 +1,52 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const JIRAIYA_ROUTINE_KEY = '__jiraiyaRoutine';
+
+export function attachJiraiyaRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 30,
+    wanderMin: 18,
+    wanderMax: 36,
+    wanderCenterJitter: 10,
+    modePool: ['walk', 'walk', 'run'],
+    startMode: 'walk',
+    wanderSettings: {
+      pauseChance: 0.68,
+      pauseMin: 1.4,
+      pauseMax: 5.6,
+      dirChangeMin: 1.8,
+      dirChangeMax: 4.6,
+    },
+    modeProfiles: {
+      walk: {
+        pauseChance: 0.45,
+        pauseMax: 4.6,
+        deviation: {
+          chance: 0.55,
+          radiusMultiplier: 1.05,
+        },
+      },
+      run: {
+        pauseChance: 0.22,
+        pauseMin: 0.7,
+        pauseMax: 2.2,
+        deviation: {
+          chance: 0.35,
+          radiusMultiplier: 0.8,
+          speedMultiplier: 0.9,
+        },
+      },
+    },
+    returnSpeeds: {
+      walk: 6.2,
+      run: 8.8,
+    },
+    ...options,
+    routineKey: JIRAIYA_ROUTINE_KEY,
+  });
+}
+
+export function updateJiraiyaRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== JIRAIYA_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/behaviors/killerBeeRoutine.js
+++ b/src/game/npcs/behaviors/killerBeeRoutine.js
@@ -1,0 +1,56 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const KILLER_BEE_ROUTINE_KEY = '__killerBeeRoutine';
+
+export function attachKillerBeeRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 24,
+    wanderMin: 12,
+    wanderMax: 28,
+    wanderCenterJitter: 12,
+    modePool: ['run', 'run', 'walk'],
+    startMode: 'run',
+    wanderSettings: {
+      pauseChance: 0.28,
+      pauseMin: 0.6,
+      pauseMax: 2.2,
+      dirChangeMin: 1.2,
+      dirChangeMax: 2.8,
+    },
+    modeProfiles: {
+      walk: {
+        pauseChance: 0.28,
+        pauseMin: 0.8,
+        pauseMax: 2.4,
+        deviation: {
+          chance: 0.45,
+          radiusMultiplier: 0.85,
+          speedMultiplier: 1.05,
+        },
+      },
+      run: {
+        pauseChance: 0.08,
+        pauseMin: 0.4,
+        pauseMax: 1.2,
+        deviation: {
+          chance: 0.38,
+          radiusMultiplier: 0.7,
+          speedMultiplier: 1.1,
+          durationMin: 1.4,
+          durationMax: 16,
+        },
+      },
+    },
+    returnSpeeds: {
+      walk: 7.4,
+      run: 10.2,
+    },
+    ...options,
+    routineKey: KILLER_BEE_ROUTINE_KEY,
+  });
+}
+
+export function updateKillerBeeRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== KILLER_BEE_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/behaviors/rockLeeRoutine.js
+++ b/src/game/npcs/behaviors/rockLeeRoutine.js
@@ -1,0 +1,46 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const ROCK_LEE_ROUTINE_KEY = '__rockLeeRoutine';
+
+export function attachRockLeeRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 22,
+    wanderMin: 10,
+    wanderMax: 24,
+    wanderCenterJitter: 8,
+    modePool: ['run'],
+    startMode: 'run',
+    wanderSettings: {
+      pauseChance: 0.18,
+      pauseMin: 0.4,
+      pauseMax: 1.6,
+      dirChangeMin: 1.0,
+      dirChangeMax: 2.2,
+    },
+    modeProfiles: {
+      run: {
+        pauseChance: 0.06,
+        pauseMin: 0.3,
+        pauseMax: 1.0,
+        deviation: {
+          chance: 0.42,
+          radiusMultiplier: 0.7,
+          speedMultiplier: 1.12,
+          durationMin: 1.2,
+          durationMax: 14,
+        },
+      },
+    },
+    returnSpeeds: {
+      walk: 7.0,
+      run: 10.0,
+    },
+    ...options,
+    routineKey: ROCK_LEE_ROUTINE_KEY,
+  });
+}
+
+export function updateRockLeeRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== ROCK_LEE_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/behaviors/tsunadeRoutine.js
+++ b/src/game/npcs/behaviors/tsunadeRoutine.js
@@ -1,0 +1,53 @@
+import { attachNarutoRoutine, updateNarutoRoutine } from './narutoRoutine.js';
+
+const TSUNADE_ROUTINE_KEY = '__tsunadeRoutine';
+
+export function attachTsunadeRoutine(npcGroup, options = {}) {
+  attachNarutoRoutine(npcGroup, {
+    wanderRadius: 18,
+    wanderMin: 16,
+    wanderMax: 32,
+    wanderCenterJitter: 5,
+    modePool: ['walk', 'walk'],
+    startMode: 'walk',
+    wanderSettings: {
+      pauseChance: 0.76,
+      pauseMin: 1.6,
+      pauseMax: 6.0,
+      dirChangeMin: 1.8,
+      dirChangeMax: 4.0,
+    },
+    modeProfiles: {
+      walk: {
+        pauseChance: 0.52,
+        pauseMin: 1.2,
+        pauseMax: 4.8,
+        deviation: {
+          chance: 0.32,
+          radiusMultiplier: 0.85,
+        },
+      },
+      run: {
+        pauseChance: 0.16,
+        pauseMin: 0.6,
+        pauseMax: 1.6,
+        deviation: {
+          chance: 0.22,
+          radiusMultiplier: 0.7,
+          speedMultiplier: 0.85,
+        },
+      },
+    },
+    returnSpeeds: {
+      walk: 6.0,
+      run: 8.4,
+    },
+    ...options,
+    routineKey: TSUNADE_ROUTINE_KEY,
+  });
+}
+
+export function updateTsunadeRoutine(npcGroup, delta, objectGrid) {
+  if (npcGroup?.userData?.__narutoRoutineKey !== TSUNADE_ROUTINE_KEY) return;
+  updateNarutoRoutine(npcGroup, delta, objectGrid);
+}

--- a/src/game/npcs/common.js
+++ b/src/game/npcs/common.js
@@ -58,6 +58,21 @@ function localBaseFor(name) {
       return 'temp/Neji/biped/';
     case 'orochimaru':
       return 'temp/Orochimaru/biped/';
+    case 'kakashi':
+      return 'temp/Kakashi_Jonin/';
+    case 'hashirama':
+      return 'temp/Kakashi_Jonin/';
+    case 'jiraiya':
+      return 'temp/Naruto/biped/';
+    case 'killerbee':
+    case 'bee':
+      return 'temp/Sasuke/';
+    case 'rocklee':
+    case 'rock':
+    case 'lee':
+      return 'temp/Neji/biped/';
+    case 'tsunade':
+      return 'temp/Sakura/biped/';
     default:
       return 'temp/';
   }

--- a/src/game/npcs/hashirama.js
+++ b/src/game/npcs/hashirama.js
@@ -1,0 +1,52 @@
+import * as THREE from 'three';
+import { createNpcRig } from './common.js';
+import { attachHashiramaRoutine } from './behaviors/hashiramaRoutine.js';
+import { getPlayerIdentity } from '../player/identity.js';
+
+const HASHIRAMA_BADGE = `data:image/svg+xml;utf8,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><rect width="128" height="128" rx="18" fill="#2e7d32"/><text x="50%" y="58%" font-size="72" text-anchor="middle" fill="#f5f5f5" font-family="Segoe UI, Arial, sans-serif">H</text></svg>'
+)}`;
+
+export function createHashirama(scene, settings, position = new THREE.Vector3()) {
+  return createNpcRig({
+    scene,
+    settings,
+    name: 'Hashirama',
+    manifestPath: './src/components/json/kakashiAnimations.json',
+    position,
+    scale: 3.1,
+    autoAdd: false,
+  }).then((group) => {
+    try {
+      group.userData.label = 'Hashirama';
+      group.userData.onInteract = (self) => {
+        try {
+          const npc = self || group;
+          npc.userData.interacting = true;
+          try { window.__npcInteracting = npc; } catch (_) {}
+          const identity = getPlayerIdentity();
+          const playerName = identity?.name || 'Kakashi Hatake';
+          const playerImage = identity?.mugshot || '/src/assets/images/mugshots/kakashi.png';
+
+          window.dispatchEvent(new CustomEvent('open-npc-dialog', {
+            detail: {
+              npc: 'Hashirama',
+              npcImage: HASHIRAMA_BADGE,
+              player: playerName,
+              playerImage,
+              lines: [
+                { speaker: 'npc', text: 'The village still feels alive. Protecting it was worth every sacrifice.' },
+                { speaker: 'player', text: 'The Will of Fire burns brighter with you watching over us, First Hokage.' },
+                { speaker: 'npc', text: 'Then let\'s keep nurturing these roots together.' },
+              ]
+            }
+          }));
+        } catch (_) {}
+      };
+    } catch (_) {}
+    try {
+      attachHashiramaRoutine(group, { spawnPosition: group.position.clone() });
+    } catch (_) {}
+    return group;
+  });
+}

--- a/src/game/npcs/jiraiya.js
+++ b/src/game/npcs/jiraiya.js
@@ -1,0 +1,52 @@
+import * as THREE from 'three';
+import { createNpcRig } from './common.js';
+import { attachJiraiyaRoutine } from './behaviors/jiraiyaRoutine.js';
+import { getPlayerIdentity } from '../player/identity.js';
+
+const JIRAIYA_BADGE = `data:image/svg+xml;utf8,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><rect width="128" height="128" rx="18" fill="#512da8"/><text x="50%" y="60%" font-size="70" text-anchor="middle" fill="#ede7f6" font-family="Segoe UI, Arial, sans-serif">J</text></svg>'
+)}`;
+
+export function createJiraiya(scene, settings, position = new THREE.Vector3()) {
+  return createNpcRig({
+    scene,
+    settings,
+    name: 'Jiraiya',
+    manifestPath: './src/components/json/narutoAnimations.json',
+    position,
+    scale: 3.2,
+    autoAdd: false,
+  }).then((group) => {
+    try {
+      group.userData.label = 'Jiraiya';
+      group.userData.onInteract = (self) => {
+        try {
+          const npc = self || group;
+          npc.userData.interacting = true;
+          try { window.__npcInteracting = npc; } catch (_) {}
+          const identity = getPlayerIdentity();
+          const playerName = identity?.name || 'Kakashi Hatake';
+          const playerImage = identity?.mugshot || '/src/assets/images/mugshots/kakashi.png';
+
+          window.dispatchEvent(new CustomEvent('open-npc-dialog', {
+            detail: {
+              npc: 'Jiraiya',
+              npcImage: JIRAIYA_BADGE,
+              player: playerName,
+              playerImage,
+              lines: [
+                { speaker: 'npc', text: 'Research never ends, even for a legendary writer like me.' },
+                { speaker: 'player', text: 'Just make sure your notes help the next generation, Ero-sennin.' },
+                { speaker: 'npc', text: 'Ha! Wisdom and inspiration, that\'s the Jiraiya way.' },
+              ]
+            }
+          }));
+        } catch (_) {}
+      };
+    } catch (_) {}
+    try {
+      attachJiraiyaRoutine(group, { spawnPosition: group.position.clone() });
+    } catch (_) {}
+    return group;
+  });
+}

--- a/src/game/npcs/killerbee.js
+++ b/src/game/npcs/killerbee.js
@@ -1,0 +1,52 @@
+import * as THREE from 'three';
+import { createNpcRig } from './common.js';
+import { attachKillerBeeRoutine } from './behaviors/killerBeeRoutine.js';
+import { getPlayerIdentity } from '../player/identity.js';
+
+const KILLER_BEE_BADGE = `data:image/svg+xml;utf8,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><rect width="128" height="128" rx="18" fill="#ff6f00"/><text x="50%" y="60%" font-size="68" text-anchor="middle" fill="#fff3e0" font-family="Segoe UI, Arial, sans-serif">B</text></svg>'
+)}`;
+
+export function createKillerBee(scene, settings, position = new THREE.Vector3()) {
+  return createNpcRig({
+    scene,
+    settings,
+    name: 'KillerBee',
+    manifestPath: './src/components/json/sasukeAnimations.json',
+    position,
+    scale: 3.15,
+    autoAdd: false,
+  }).then((group) => {
+    try {
+      group.userData.label = 'Killer Bee';
+      group.userData.onInteract = (self) => {
+        try {
+          const npc = self || group;
+          npc.userData.interacting = true;
+          try { window.__npcInteracting = npc; } catch (_) {}
+          const identity = getPlayerIdentity();
+          const playerName = identity?.name || 'Kakashi Hatake';
+          const playerImage = identity?.mugshot || '/src/assets/images/mugshots/kakashi.png';
+
+          window.dispatchEvent(new CustomEvent('open-npc-dialog', {
+            detail: {
+              npc: 'Killer Bee',
+              npcImage: KILLER_BEE_BADGE,
+              player: playerName,
+              playerImage,
+              lines: [
+                { speaker: 'npc', text: 'Yo! Eight-Tails jinchuriki in the zone, spitting rhythm and keeping the peace!' },
+                { speaker: 'player', text: 'Just don\'t outpace the rest of us with that energy, Bee.' },
+                { speaker: 'npc', text: 'Relax, bro! We\'ll move together and groove together.' },
+              ]
+            }
+          }));
+        } catch (_) {}
+      };
+    } catch (_) {}
+    try {
+      attachKillerBeeRoutine(group, { spawnPosition: group.position.clone() });
+    } catch (_) {}
+    return group;
+  });
+}

--- a/src/game/npcs/rocklee.js
+++ b/src/game/npcs/rocklee.js
@@ -1,0 +1,52 @@
+import * as THREE from 'three';
+import { createNpcRig } from './common.js';
+import { attachRockLeeRoutine } from './behaviors/rockLeeRoutine.js';
+import { getPlayerIdentity } from '../player/identity.js';
+
+const ROCK_LEE_BADGE = `data:image/svg+xml;utf8,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><rect width="128" height="128" rx="18" fill="#1b5e20"/><text x="50%" y="60%" font-size="68" text-anchor="middle" fill="#e8f5e9" font-family="Segoe UI, Arial, sans-serif">L</text></svg>'
+)}`;
+
+export function createRockLee(scene, settings, position = new THREE.Vector3()) {
+  return createNpcRig({
+    scene,
+    settings,
+    name: 'RockLee',
+    manifestPath: './src/components/json/nejiAnimations.json',
+    position,
+    scale: 3.0,
+    autoAdd: false,
+  }).then((group) => {
+    try {
+      group.userData.label = 'Rock Lee';
+      group.userData.onInteract = (self) => {
+        try {
+          const npc = self || group;
+          npc.userData.interacting = true;
+          try { window.__npcInteracting = npc; } catch (_) {}
+          const identity = getPlayerIdentity();
+          const playerName = identity?.name || 'Kakashi Hatake';
+          const playerImage = identity?.mugshot || '/src/assets/images/mugshots/kakashi.png';
+
+          window.dispatchEvent(new CustomEvent('open-npc-dialog', {
+            detail: {
+              npc: 'Rock Lee',
+              npcImage: ROCK_LEE_BADGE,
+              player: playerName,
+              playerImage,
+              lines: [
+                { speaker: 'npc', text: 'Hard work is my nindo! Have you trained today?' },
+                { speaker: 'player', text: 'Not as much as you, Lee. Teach me a new drill later.' },
+                { speaker: 'npc', text: 'With the power of youth, we will surpass every limit!' },
+              ]
+            }
+          }));
+        } catch (_) {}
+      };
+    } catch (_) {}
+    try {
+      attachRockLeeRoutine(group, { spawnPosition: group.position.clone() });
+    } catch (_) {}
+    return group;
+  });
+}

--- a/src/game/npcs/tsunade.js
+++ b/src/game/npcs/tsunade.js
@@ -1,0 +1,52 @@
+import * as THREE from 'three';
+import { createNpcRig } from './common.js';
+import { attachTsunadeRoutine } from './behaviors/tsunadeRoutine.js';
+import { getPlayerIdentity } from '../player/identity.js';
+
+const TSUNADE_BADGE = `data:image/svg+xml;utf8,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><rect width="128" height="128" rx="18" fill="#c62828"/><text x="50%" y="60%" font-size="68" text-anchor="middle" fill="#ffebee" font-family="Segoe UI, Arial, sans-serif">T</text></svg>'
+)}`;
+
+export function createTsunade(scene, settings, position = new THREE.Vector3()) {
+  return createNpcRig({
+    scene,
+    settings,
+    name: 'Tsunade',
+    manifestPath: './src/components/json/sakuraAnimations.json',
+    position,
+    scale: 3.05,
+    autoAdd: false,
+  }).then((group) => {
+    try {
+      group.userData.label = 'Tsunade';
+      group.userData.onInteract = (self) => {
+        try {
+          const npc = self || group;
+          npc.userData.interacting = true;
+          try { window.__npcInteracting = npc; } catch (_) {}
+          const identity = getPlayerIdentity();
+          const playerName = identity?.name || 'Kakashi Hatake';
+          const playerImage = identity?.mugshot || '/src/assets/images/mugshots/kakashi.png';
+
+          window.dispatchEvent(new CustomEvent('open-npc-dialog', {
+            detail: {
+              npc: 'Tsunade',
+              npcImage: TSUNADE_BADGE,
+              player: playerName,
+              playerImage,
+              lines: [
+                { speaker: 'npc', text: 'Paperwork, patients, politics... being Hokage never slows down.' },
+                { speaker: 'player', text: 'We\'ll keep the village steady for you, Lady Tsunade.' },
+                { speaker: 'npc', text: 'Good. Then maybe I can sneak in a moment of sake later.' },
+              ]
+            }
+          }));
+        } catch (_) {}
+      };
+    } catch (_) {}
+    try {
+      attachTsunadeRoutine(group, { spawnPosition: group.position.clone() });
+    } catch (_) {}
+    return group;
+  });
+}

--- a/src/hooks/sceneLifecycle.js
+++ b/src/hooks/sceneLifecycle.js
@@ -7,6 +7,11 @@ import { createSakura } from '../game/npcs/sakura.js';
 import { createShikamaru } from '../game/npcs/shikamaru.js';
 import { createNeji } from '../game/npcs/neji.js';
 import { createOrochimaru } from '../game/npcs/orochimaru.js';
+import { createHashirama } from '../game/npcs/hashirama.js';
+import { createJiraiya } from '../game/npcs/jiraiya.js';
+import { createKillerBee } from '../game/npcs/killerbee.js';
+import { createRockLee } from '../game/npcs/rocklee.js';
+import { createTsunade } from '../game/npcs/tsunade.js';
 import { getPlayerIdentity } from '../game/player/identity.js';
 import { parseGridLabel, posForCell } from '../game/objects/utils/gridLabel.js';
 import { WORLD_SIZE } from '../scene/terrain.js';
@@ -67,7 +72,12 @@ export function initThreeScene({
               { key: 'sakura', label: 'Sakura', spawnLabel: 'KN318', create: createSakura },
               { key: 'shikamaru', label: 'Shikamaru', spawnLabel: 'RJ416', create: createShikamaru },
               { key: 'neji', label: 'Neji', offset: new THREE.Vector3(8, 0, 8), create: createNeji },
-              { key: 'orochimaru', label: 'Orochimaru', offset: new THREE.Vector3(-8, 0, 8), create: createOrochimaru }
+              { key: 'orochimaru', label: 'Orochimaru', offset: new THREE.Vector3(-8, 0, 8), create: createOrochimaru },
+              { key: 'hashirama', label: 'Hashirama', spawnLabel: 'QP410', create: createHashirama },
+              { key: 'jiraiya', label: 'Jiraiya', spawnLabel: 'PP392', create: createJiraiya },
+              { key: 'killerbee', label: 'Killer Bee', offset: new THREE.Vector3(-14, 0, -10), create: createKillerBee },
+              { key: 'rocklee', label: 'Rock Lee', offset: new THREE.Vector3(14, 0, -8), create: createRockLee },
+              { key: 'tsunade', label: 'Tsunade', spawnLabel: 'MO376', create: createTsunade }
             ];
 
             const activeEntries = spawnEntries.filter((entry) => entry.key !== identityKey);

--- a/src/scene/animationLoop.js
+++ b/src/scene/animationLoop.js
@@ -9,6 +9,11 @@ import { updateSakuraRoutine } from '/src/game/npcs/behaviors/sakuraRoutine.js';
 import { updateShikamaruRoutine } from '/src/game/npcs/behaviors/shikamaruRoutine.js';
 import { updateNejiRoutine } from '/src/game/npcs/behaviors/nejiRoutine.js';
 import { updateOrochimaruRoutine } from '/src/game/npcs/behaviors/orochimaruRoutine.js';
+import { updateHashiramaRoutine } from '/src/game/npcs/behaviors/hashiramaRoutine.js';
+import { updateJiraiyaRoutine } from '/src/game/npcs/behaviors/jiraiyaRoutine.js';
+import { updateKillerBeeRoutine } from '/src/game/npcs/behaviors/killerBeeRoutine.js';
+import { updateRockLeeRoutine } from '/src/game/npcs/behaviors/rockLeeRoutine.js';
+import { updateTsunadeRoutine } from '/src/game/npcs/behaviors/tsunadeRoutine.js';
 import { ensureNpcCollisionIdle, monitorNpcLocomotion } from '/src/game/npcs/common.js';
 import { INTERACTION_DISTANCE } from '../game/constants.js';
 import { multiplayerManager } from '../network/multiplayerManager.js';
@@ -333,6 +338,11 @@ export function startAnimationLoop({
                     try { updateShikamaruRoutine(g, delta, objectGridRef.current); } catch (_) {}
                     try { updateNejiRoutine(g, delta, objectGridRef.current); } catch (_) {}
                     try { updateOrochimaruRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateHashiramaRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateJiraiyaRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateKillerBeeRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateRockLeeRoutine(g, delta, objectGridRef.current); } catch (_) {}
+                    try { updateTsunadeRoutine(g, delta, objectGridRef.current); } catch (_) {}
                     try { monitorNpcLocomotion(g, delta); } catch (_) {}
                     // Ensure mixer advances regardless
                     try { g?.userData?.mixer?.update(delta); } catch (_) {}


### PR DESCRIPTION
## Summary
- add NPC rigs and dialog hooks for Hashirama, Jiraiya, Killer Bee, Rock Lee, and Tsunade
- create character-specific patrol wrappers that reuse the Naruto routine with tuned pacing
- register the new legends with squad spawning, fallback rosters, and asset fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e42cae1f9c833289c2c8b256f81886