### PR TITLE
Prefer local temp NPC assets for legend rigs

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,5 @@
 Recent
+- NPCs: Hashirama, Jiraiya, Killer Bee, Rock Lee, and Tsunade now load their temp-packaged GLBs before remote fallbacks so their updated models appear in-game.
 - Main Menu: Changelog button now opens the live changes.md file inside the modal for a single source of truth.
 - Docs: Added showcase automation playbook covering changelog review, running the server, and refreshing modal screenshots.
 - Campaign: Added a six-arc narrative campaign with sequential mission progression, cinematics, and a main menu overview panel.

--- a/src/game/npcs/common.js
+++ b/src/game/npcs/common.js
@@ -103,44 +103,42 @@ export async function loadCharacterAssetsFromManifest(manifestPath, essential = 
 
   const essentials = urls.filter((u) => essential.some((m) => u.endsWith(m)));
   const toLoad = essentials.length ? essentials : [urls[0]];
-  const normalizedTargets = toLoad.map((url) => normalizeUrl(url));
+  const normalizedTargets = Array.from(new Set(toLoad.map((url) => normalizeUrl(url)))).filter(Boolean);
 
-  let assets = (await Promise.all(
-    normalizedTargets.map((url) =>
-      new Promise((resolve) =>
-        loader.load(
-          url,
-          (gltf) => resolve({ gltf, url }),
-          undefined,
-          () => resolve(null)
+  const fileNames = toFileNames(urls);
+  const localUrls = fileNames.map((fn) => `${localBase}${fn}`);
+  const localEssentials = localUrls.filter((u) => essential.some((m) => u.endsWith(m)));
+  const localToLoad = Array.from(new Set((localEssentials.length ? localEssentials : localUrls))).filter(Boolean);
+
+  const loadTargets = async (targets) =>
+    (
+      await Promise.all(
+        targets.map(
+          (url) =>
+            new Promise((resolve) =>
+              loader.load(
+                url,
+                (gltf) => resolve({ gltf, url }),
+                undefined,
+                () => resolve(null)
+              )
+            )
         )
       )
-    )
-  )).filter(Boolean);
+    ).filter(Boolean);
 
-  // Fallback: if remote GLBs failed (e.g., CORS/404), try local temp files using the same filenames
-  if (!assets.length) {
+  let assets = [];
+
+  if (localToLoad.length) {
     try {
-      const fileNames = toFileNames(urls);
-      const localUrls = fileNames.map((fn) => `${localBase}${fn}`);
-      const localEssentials = localUrls.filter((u) => essential.some((m) => u.endsWith(m)));
-      const localToLoad = localEssentials.length ? localEssentials : localUrls;
-
-      assets = (await Promise.all(
-        localToLoad.map((url) =>
-          new Promise((resolve) =>
-            loader.load(
-              url,
-              (gltf) => resolve({ gltf, url }),
-              undefined,
-              () => resolve(null)
-            )
-          )
-        )
-      )).filter(Boolean);
+      assets = await loadTargets(localToLoad);
     } catch (_) {
-      // ignore, will error below if still empty
+      assets = [];
     }
+  }
+
+  if (!assets.length && normalizedTargets.length) {
+    assets = await loadTargets(normalizedTargets);
   }
 
   if (!assets.length) throw new Error(`Could not load any GLB from manifest: ${manifestPath}`);


### PR DESCRIPTION
## Summary
- update the shared NPC asset loader to try local temp GLBs before remote URLs
- ensure Hashirama, Jiraiya, Killer Bee, Rock Lee, and Tsunade immediately use their bundled models
- document the change in the running changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e42f57e23c83328ebbc022d60eeddc