### PR TITLE
Fix NPC animation manifests

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -72,3 +72,4 @@ Recent
 
 - NPCs: Added Hashirama, Jiraiya, Killer Bee, Rock Lee, and Tsunade with bespoke patrol tuning and dialog badges.
 - Systems: Expanded squad spawning and roster fallbacks so the new legends join existing patrol updates.
+2025-10-06 21:27:43 - NPCs: Point new legends to their dedicated animation manifests and local temp rigs.

--- a/src/components/json/hashiramaAnimations.json
+++ b/src/components/json/hashiramaAnimations.json
@@ -1,0 +1,12 @@
+{
+  "files": [
+    "Animation_Idle_11_withSkin.glb",
+    "Animation_Casual_Walk_withSkin.glb",
+    "Animation_Walking_withSkin.glb",
+    "Animation_Running_withSkin.glb",
+    "Animation_Listening_Gesture_withSkin.glb",
+    "Animation_Stand_and_Chat_withSkin.glb",
+    "Animation_Talk_with_Right_Hand_Open_withSkin.glb",
+    "Animation_Charged_Ground_Slam_withSkin.glb"
+  ]
+}

--- a/src/components/json/jiraiyaAnimations.json
+++ b/src/components/json/jiraiyaAnimations.json
@@ -1,0 +1,13 @@
+{
+  "files": [
+    "Animation_Idle_11_withSkin.glb",
+    "Animation_Casual_Walk_withSkin.glb",
+    "Animation_Walking_withSkin.glb",
+    "Animation_Running_withSkin.glb",
+    "Animation_Listening_Gesture_withSkin.glb",
+    "Animation_Stand_and_Chat_withSkin.glb",
+    "Animation_Talk_with_Right_Hand_Open_withSkin.glb",
+    "Animation_Talk_with_Left_Hand_Raised_withSkin.glb",
+    "Animation_Charged_Ground_Slam_withSkin.glb"
+  ]
+}

--- a/src/components/json/killerBeeAnimations.json
+++ b/src/components/json/killerBeeAnimations.json
@@ -1,0 +1,12 @@
+{
+  "files": [
+    "Animation_Casual_Walk_withSkin.glb",
+    "Animation_Walking_withSkin.glb",
+    "Animation_Running_withSkin.glb",
+    "Animation_Listening_Gesture_withSkin.glb",
+    "Animation_Talk_with_Hands_Open_withSkin.glb",
+    "Animation_Talk_Passionately_withSkin.glb",
+    "Animation_Charged_Ground_Slam_withSkin.glb",
+    "Animation_open_door_1_withSkin.glb"
+  ]
+}

--- a/src/components/json/rockLeeAnimations.json
+++ b/src/components/json/rockLeeAnimations.json
@@ -1,0 +1,12 @@
+{
+  "files": [
+    "Animation_Walking_withSkin.glb",
+    "Animation_Running_withSkin.glb",
+    "Animation_Listening_Gesture_withSkin.glb",
+    "Animation_Stand_and_Chat_withSkin.glb",
+    "Animation_Talk_with_Right_Hand_Open_withSkin.glb",
+    "Animation_Backflip_withSkin.glb",
+    "Animation_Handstand_Flip_withSkin.glb",
+    "Animation_open_door_1_withSkin.glb"
+  ]
+}

--- a/src/components/json/tsunadeAnimations.json
+++ b/src/components/json/tsunadeAnimations.json
@@ -1,0 +1,11 @@
+{
+  "files": [
+    "Animation_Idle_7_withSkin.glb",
+    "Animation_Casual_Walk_withSkin.glb",
+    "Animation_Walking_withSkin.glb",
+    "Animation_Running_withSkin.glb",
+    "Animation_Listening_Gesture_withSkin.glb",
+    "Animation_Stand_and_Chat_withSkin.glb",
+    "Animation_Charged_Ground_Slam_withSkin.glb"
+  ]
+}

--- a/src/game/npcs/common.js
+++ b/src/game/npcs/common.js
@@ -61,18 +61,19 @@ function localBaseFor(name) {
     case 'kakashi':
       return 'temp/Kakashi_Jonin/';
     case 'hashirama':
-      return 'temp/Kakashi_Jonin/';
+      return 'temp/hashirama/biped/';
     case 'jiraiya':
-      return 'temp/Naruto/biped/';
+      return 'temp/jiraiya/biped/';
     case 'killerbee':
+    case 'killer':
     case 'bee':
-      return 'temp/Sasuke/';
+      return 'temp/killerbee/biped/';
     case 'rocklee':
     case 'rock':
     case 'lee':
-      return 'temp/Neji/biped/';
+      return 'temp/rocklee/biped/';
     case 'tsunade':
-      return 'temp/Sakura/biped/';
+      return 'temp/tsunade/biped/';
     default:
       return 'temp/';
   }

--- a/src/game/npcs/hashirama.js
+++ b/src/game/npcs/hashirama.js
@@ -12,7 +12,7 @@ export function createHashirama(scene, settings, position = new THREE.Vector3())
     scene,
     settings,
     name: 'Hashirama',
-    manifestPath: './src/components/json/kakashiAnimations.json',
+    manifestPath: './src/components/json/hashiramaAnimations.json',
     position,
     scale: 3.1,
     autoAdd: false,

--- a/src/game/npcs/jiraiya.js
+++ b/src/game/npcs/jiraiya.js
@@ -12,7 +12,7 @@ export function createJiraiya(scene, settings, position = new THREE.Vector3()) {
     scene,
     settings,
     name: 'Jiraiya',
-    manifestPath: './src/components/json/narutoAnimations.json',
+    manifestPath: './src/components/json/jiraiyaAnimations.json',
     position,
     scale: 3.2,
     autoAdd: false,

--- a/src/game/npcs/killerbee.js
+++ b/src/game/npcs/killerbee.js
@@ -12,7 +12,7 @@ export function createKillerBee(scene, settings, position = new THREE.Vector3())
     scene,
     settings,
     name: 'KillerBee',
-    manifestPath: './src/components/json/sasukeAnimations.json',
+    manifestPath: './src/components/json/killerBeeAnimations.json',
     position,
     scale: 3.15,
     autoAdd: false,

--- a/src/game/npcs/rocklee.js
+++ b/src/game/npcs/rocklee.js
@@ -12,7 +12,7 @@ export function createRockLee(scene, settings, position = new THREE.Vector3()) {
     scene,
     settings,
     name: 'RockLee',
-    manifestPath: './src/components/json/nejiAnimations.json',
+    manifestPath: './src/components/json/rockLeeAnimations.json',
     position,
     scale: 3.0,
     autoAdd: false,

--- a/src/game/npcs/tsunade.js
+++ b/src/game/npcs/tsunade.js
@@ -12,7 +12,7 @@ export function createTsunade(scene, settings, position = new THREE.Vector3()) {
     scene,
     settings,
     name: 'Tsunade',
-    manifestPath: './src/components/json/sakuraAnimations.json',
+    manifestPath: './src/components/json/tsunadeAnimations.json',
     position,
     scale: 3.05,
     autoAdd: false,


### PR DESCRIPTION
## Summary
- add animation manifest json files for Hashirama, Jiraiya, Killer Bee, Rock Lee, and Tsunade
- update the NPC loader to use the new manifests and their temp animation folders

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4335199f08332abd4a5dde6ce5ac3